### PR TITLE
feat: redesign skill tree map (swimlanes, sub-levels, status)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@tanstack/react-query": "^5.97.0",
+        "@xyflow/react": "^12.10.2",
+        "dagre": "^0.8.5",
+        "js-yaml": "^4.1.1",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router": "^7.14.0",
@@ -1161,6 +1164,55 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1219,6 +1271,66 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@xyflow/react": {
+      "version": "12.10.2",
+      "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.10.2.tgz",
+      "integrity": "sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@xyflow/system": "0.0.76",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.0"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xyflow/system": {
+      "version": "0.0.76",
+      "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.76.tgz",
+      "integrity": "sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-drag": "^3.0.7",
+        "@types/d3-interpolate": "^3.0.4",
+        "@types/d3-selection": "^3.0.10",
+        "@types/d3-transition": "^3.0.8",
+        "@types/d3-zoom": "^3.0.8",
+        "d3-drag": "^3.0.0",
+        "d3-interpolate": "^3.0.1",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0"
       }
     },
     "node_modules/acorn": {
@@ -1281,7 +1393,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/balanced-match": {
@@ -1397,6 +1508,12 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1465,6 +1582,121 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1877,6 +2109,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1992,7 +2233,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2348,6 +2588,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -2854,6 +3100,15 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/vite": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.97.0",
+    "@xyflow/react": "^12.10.2",
+    "dagre": "^0.8.5",
+    "js-yaml": "^4.1.1",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router": "^7.14.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import { useSessionStore } from "./stores/sessionStore"
 import WelcomeScreen from "./components/screens/WelcomeScreen"
 import QuestionScreen from "./components/screens/QuestionScreen"
 import DiagnosticScreen from "./components/screens/DiagnosticScreen"
+import SkillTreeScreen from "./components/screens/SkillTreeScreen"
 import "./App.css"
 
 export default function App() {
@@ -43,6 +44,7 @@ export default function App() {
           <DiagnosticScreen analysis={store.analysis} onRestart={handleRestart} />
         ) : null
       } />
+      <Route path="/skill-tree" element={<SkillTreeScreen />} />
     </Routes>
   )
 }

--- a/src/components/screens/SkillTreeScreen.jsx
+++ b/src/components/screens/SkillTreeScreen.jsx
@@ -4,106 +4,196 @@ import {
   Background,
   Controls,
   MiniMap,
+  MarkerType,
   useNodesState,
   useEdgesState,
 } from "@xyflow/react"
-import dagre from "dagre"
 import yaml from "js-yaml"
 import skillsRaw from "../../../backend/app/skill_tree/skills.yaml?raw"
 import "@xyflow/react/dist/style.css"
 import SkillNode from "../ui/SkillNode"
 import { levelDescriptions } from "../../lib/constants"
+import {
+  GRADES,
+  GRADE_COLORS,
+  buildGraph,
+  collectRelated,
+} from "../../lib/skillTreeLayout"
 
-const GRADE_COLORS = {
-  P1: { bg: "#8cfece", border: "#00694b", text: "#004d36", minimap: "#00694b" },
-  P2: { bg: "#fecb00", border: "#705900", text: "#413200", minimap: "#705900" },
-  P3: { bg: "#68a0ff", border: "#0059b6", text: "#00224d", minimap: "#0059b6" },
-  P4: { bg: "#f0c8ff", border: "#7b3d96", text: "#4a1264", minimap: "#7b3d96" },
-  P5: { bg: "#ffb68a", border: "#b64600", text: "#5c2200", minimap: "#b64600" },
-  P6: { bg: "#d4dbff", border: "#505a81", text: "#222d51", minimap: "#505a81" },
+function LaneLabel({ data }) {
+  const { grade, colors, width, height } = data
+  return (
+    <div className="pointer-events-none flex items-center" style={{ width, height }}>
+      <div
+        className="flex flex-col items-center justify-center rounded-2xl px-3 py-4 shrink-0"
+        style={{
+          background: `linear-gradient(135deg, ${colors.bg}, ${colors.bg}aa)`,
+          border: `1.5px solid ${colors.border}`,
+          width: 130,
+        }}
+      >
+        <span className="text-lg font-bold font-headline" style={{ color: colors.text }}>
+          {grade}
+        </span>
+        <span className="text-[10px] text-center leading-tight mt-0.5" style={{ color: colors.text }}>
+          {levelDescriptions[grade]}
+        </span>
+      </div>
+      <div
+        className="flex-1 h-[85%] ml-6 rounded-xl"
+        style={{ backgroundColor: colors.bg, opacity: 0.15 }}
+      />
+    </div>
+  )
 }
 
-const NODE_WIDTH = 220
-const NODE_HEIGHT = 60
-
-function buildGraph(skills) {
-  const g = new dagre.graphlib.Graph()
-  g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 80, marginx: 40, marginy: 40 })
-  g.setDefaultEdgeLabel(() => ({}))
-
-  for (const skill of skills) {
-    g.setNode(skill.id, { width: NODE_WIDTH, height: NODE_HEIGHT })
-  }
-
-  const edges = []
-  for (const skill of skills) {
-    for (const prereqId of skill.prerequisites) {
-      g.setEdge(prereqId, skill.id)
-      edges.push({
-        id: `${prereqId}->${skill.id}`,
-        source: prereqId,
-        target: skill.id,
-        type: "smoothstep",
-        animated: false,
-        style: { stroke: "#a1abd7", strokeWidth: 1.5 },
-      })
-    }
-  }
-
-  dagre.layout(g)
-
-  const nodes = skills.map((skill) => {
-    const pos = g.node(skill.id)
-    const colors = GRADE_COLORS[skill.grade]
-    return {
-      id: skill.id,
-      type: "skillNode",
-      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 },
-      data: { ...skill, colors },
-    }
-  })
-
-  return { nodes, edges }
-}
-
-const nodeTypes = { skillNode: SkillNode }
+const nodeTypes = { skillNode: SkillNode, laneLabel: LaneLabel }
 
 export default function SkillTreeScreen() {
   const skills = useMemo(() => yaml.load(skillsRaw), [])
-  const { nodes: initialNodes, edges: initialEdges } = useMemo(
-    () => buildGraph(skills),
-    [skills]
+  const nextId = useMemo(() => skills.find((s) => s.grade === "P2")?.id ?? null, [skills])
+
+  const { nodes: initialNodes, edges: initialEdges, successors } = useMemo(
+    () => buildGraph(skills, nextId),
+    [skills, nextId]
   )
 
-  const [nodes, , onNodesChange] = useNodesState(initialNodes)
-  const [edges, , onEdgesChange] = useEdgesState(initialEdges)
+  const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
+  const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
   const [selected, setSelected] = useState(null)
+  const [query, setQuery] = useState("")
+  const [gradeFilter, setGradeFilter] = useState(null)
+
+  const applyHighlight = useCallback(
+    (focusId, q, grade) => {
+      const related = focusId ? collectRelated(focusId, skills, successors) : null
+      const needle = q.trim().toLowerCase()
+      const matchesQuery = (s) =>
+        !needle ||
+        s.label.toLowerCase().includes(needle) ||
+        s.id.toLowerCase().includes(needle)
+
+      setNodes((ns) =>
+        ns.map((n) => {
+          if (n.type === "laneLabel") {
+            const dim = grade && n.data.grade !== grade
+            return { ...n, style: { ...n.style, opacity: dim ? 0.3 : 1 } }
+          }
+          if (n.type !== "skillNode") return n
+          const s = n.data
+          let dim = false
+          if (related) {
+            dim = s.id !== focusId && !related.ancestors.has(s.id)
+          }
+          if (grade) dim = dim || s.grade !== grade
+          if (needle) dim = dim || !matchesQuery(s)
+          return { ...n, style: { ...n.style, opacity: dim ? 0.2 : 1 } }
+        })
+      )
+      setEdges((es) =>
+        es.map((e) => {
+          let active = true
+          if (related) {
+            active =
+              (related.ancestors.has(e.source) || e.source === focusId) &&
+              (related.ancestors.has(e.target) || e.target === focusId)
+          }
+          const color = active && related ? "#0059b6" : "#c2c7dd"
+          return {
+            ...e,
+            style: {
+              ...e.style,
+              stroke: color,
+              strokeWidth: active && related ? 2.5 : 1.5,
+              strokeDasharray: active && related ? "0" : "6 6",
+              opacity: active ? 1 : 0.1,
+            },
+            markerEnd: { type: MarkerType.ArrowClosed, color, width: 14, height: 14 },
+          }
+        })
+      )
+    },
+    [skills, successors, setNodes, setEdges]
+  )
 
   const onNodeClick = useCallback(
-    (_, node) => setSelected(node.data),
-    []
+    (_, node) => {
+      if (node.type !== "skillNode") return
+      setSelected(node.data)
+      applyHighlight(node.id, query, gradeFilter)
+    },
+    [applyHighlight, query, gradeFilter]
   )
 
-  const onPaneClick = useCallback(() => setSelected(null), [])
+  const onPaneClick = useCallback(() => {
+    setSelected(null)
+    applyHighlight(null, query, gradeFilter)
+  }, [applyHighlight, query, gradeFilter])
+
+  const onQueryChange = useCallback(
+    (e) => {
+      const v = e.target.value
+      setQuery(v)
+      applyHighlight(selected?.id ?? null, v, gradeFilter)
+    },
+    [applyHighlight, selected, gradeFilter]
+  )
+
+  const selectGrade = useCallback(
+    (g) => {
+      const next = gradeFilter === g ? null : g
+      setGradeFilter(next)
+      applyHighlight(selected?.id ?? null, query, next)
+    },
+    [applyHighlight, gradeFilter, query, selected]
+  )
 
   const minimapColor = useCallback(
-    (node) => node.data?.colors?.minimap ?? "#a1abd7",
+    (node) => node.data?.colors?.minimap ?? "#c2c7dd",
     []
   )
 
   return (
     <div className="h-screen w-screen flex flex-col bg-background">
-      <header className="flex items-center gap-4 px-6 py-3 border-b border-outline-variant/30">
-        <a
-          href="/"
-          className="text-primary hover:text-primary-dim transition-colors text-sm font-medium"
-        >
+      <header className="flex items-center gap-6 px-8 py-4 border-b border-outline-variant/30">
+        <a href="/" className="text-primary hover:text-primary-dim text-sm font-medium">
           ← Accueil
         </a>
-        <h1 className="font-headline text-lg font-bold text-on-background">
-          Arbre de compétences
-        </h1>
-        <Legend />
+        <div>
+          <h1 className="font-headline text-xl font-bold text-on-background leading-tight">
+            Carte des Compétences
+          </h1>
+          <p className="text-xs text-on-surface-variant">
+            Explorez le parcours mathématique et visualisez vos forces
+          </p>
+        </div>
+        <div className="flex items-center gap-1 ml-4">
+          {GRADES.map((g) => {
+            const active = gradeFilter === g
+            const colors = GRADE_COLORS[g]
+            return (
+              <button
+                key={g}
+                onClick={() => selectGrade(g)}
+                className="text-xs font-semibold px-3 py-1.5 rounded-full transition-all"
+                style={{
+                  background: active ? colors.border : "transparent",
+                  color: active ? "#fff" : colors.text,
+                  border: `1.5px solid ${active ? colors.border : colors.bg}`,
+                }}
+              >
+                {g}
+              </button>
+            )
+          })}
+        </div>
+        <input
+          type="search"
+          value={query}
+          onChange={onQueryChange}
+          placeholder="Rechercher une compétence…"
+          className="ml-auto px-3 py-1.5 text-sm rounded-full border border-outline-variant/50 bg-surface-container focus:outline-none focus:border-primary w-64"
+        />
       </header>
 
       <div className="flex-1 relative">
@@ -117,35 +207,43 @@ export default function SkillTreeScreen() {
           nodeTypes={nodeTypes}
           fitView
           fitViewOptions={{ padding: 0.15 }}
-          minZoom={0.1}
+          minZoom={0.15}
           maxZoom={2}
+          panOnScroll
+          zoomOnScroll={false}
+          zoomOnPinch
           proOptions={{ hideAttribution: true }}
         >
-          <Background color="#a1abd7" gap={24} size={1} />
-          <Controls position="bottom-right" />
+          <Background color="#d4d8ea" gap={28} size={1} />
+          <Controls position="bottom-right" showInteractive={false} />
           <MiniMap
             nodeColor={minimapColor}
             maskColor="rgba(244, 242, 255, 0.7)"
             position="bottom-left"
+            pannable
+            zoomable
           />
         </ReactFlow>
 
-        {selected && <DetailPanel skill={selected} onClose={() => setSelected(null)} />}
+        {selected && <DetailPanel skill={selected} onClose={onPaneClick} />}
+        <StatusLegend />
       </div>
     </div>
   )
 }
 
-function Legend() {
+function StatusLegend() {
+  const items = [
+    { label: "Complétée", color: "#00694b", ring: "solid" },
+    { label: "En cours", color: "#8a6d00", ring: "dashed" },
+    { label: "Verrouillée", color: "#b0b5c9", ring: "solid" },
+  ]
   return (
-    <div className="ml-auto flex items-center gap-3">
-      {Object.entries(GRADE_COLORS).map(([grade, colors]) => (
-        <div key={grade} className="flex items-center gap-1.5 text-xs">
-          <span
-            className="w-3 h-3 rounded-sm"
-            style={{ backgroundColor: colors.bg, border: `1.5px solid ${colors.border}` }}
-          />
-          <span className="text-on-surface-variant">{grade}</span>
+    <div className="absolute bottom-4 right-20 flex flex-col gap-1.5 bg-surface-container/90 backdrop-blur px-3 py-2 rounded-xl shadow-ambient-sm">
+      {items.map(({ label, color, ring }) => (
+        <div key={label} className="flex items-center gap-2 text-xs text-on-surface-variant">
+          <span className="w-3 h-3 rounded-full" style={{ border: `2px ${ring} ${color}` }} />
+          {label}
         </div>
       ))}
     </div>
@@ -155,10 +253,10 @@ function Legend() {
 function DetailPanel({ skill, onClose }) {
   const colors = GRADE_COLORS[skill.grade]
   return (
-    <div className="absolute top-4 right-4 w-80 glass-card ghost-border shadow-ambient rounded-xl p-5 z-50">
+    <div className="absolute top-4 right-4 w-80 glass-card ghost-border shadow-ambient rounded-2xl p-5 z-50">
       <div className="flex items-start justify-between mb-3">
         <span
-          className="text-xs font-medium px-2 py-0.5 rounded-full"
+          className="text-xs font-medium px-2.5 py-0.5 rounded-full"
           style={{ backgroundColor: colors.bg, color: colors.text }}
         >
           {skill.grade} — {levelDescriptions[skill.grade]}

--- a/src/components/screens/SkillTreeScreen.jsx
+++ b/src/components/screens/SkillTreeScreen.jsx
@@ -1,0 +1,197 @@
+import { useState, useCallback, useMemo } from "react"
+import {
+  ReactFlow,
+  Background,
+  Controls,
+  MiniMap,
+  useNodesState,
+  useEdgesState,
+} from "@xyflow/react"
+import dagre from "dagre"
+import yaml from "js-yaml"
+import skillsRaw from "../../../backend/app/skill_tree/skills.yaml?raw"
+import "@xyflow/react/dist/style.css"
+import SkillNode from "../ui/SkillNode"
+import { levelDescriptions } from "../../lib/constants"
+
+const GRADE_COLORS = {
+  P1: { bg: "#8cfece", border: "#00694b", text: "#004d36", minimap: "#00694b" },
+  P2: { bg: "#fecb00", border: "#705900", text: "#413200", minimap: "#705900" },
+  P3: { bg: "#68a0ff", border: "#0059b6", text: "#00224d", minimap: "#0059b6" },
+  P4: { bg: "#f0c8ff", border: "#7b3d96", text: "#4a1264", minimap: "#7b3d96" },
+  P5: { bg: "#ffb68a", border: "#b64600", text: "#5c2200", minimap: "#b64600" },
+  P6: { bg: "#d4dbff", border: "#505a81", text: "#222d51", minimap: "#505a81" },
+}
+
+const NODE_WIDTH = 220
+const NODE_HEIGHT = 60
+
+function buildGraph(skills) {
+  const g = new dagre.graphlib.Graph()
+  g.setGraph({ rankdir: "TB", nodesep: 40, ranksep: 80, marginx: 40, marginy: 40 })
+  g.setDefaultEdgeLabel(() => ({}))
+
+  for (const skill of skills) {
+    g.setNode(skill.id, { width: NODE_WIDTH, height: NODE_HEIGHT })
+  }
+
+  const edges = []
+  for (const skill of skills) {
+    for (const prereqId of skill.prerequisites) {
+      g.setEdge(prereqId, skill.id)
+      edges.push({
+        id: `${prereqId}->${skill.id}`,
+        source: prereqId,
+        target: skill.id,
+        type: "smoothstep",
+        animated: false,
+        style: { stroke: "#a1abd7", strokeWidth: 1.5 },
+      })
+    }
+  }
+
+  dagre.layout(g)
+
+  const nodes = skills.map((skill) => {
+    const pos = g.node(skill.id)
+    const colors = GRADE_COLORS[skill.grade]
+    return {
+      id: skill.id,
+      type: "skillNode",
+      position: { x: pos.x - NODE_WIDTH / 2, y: pos.y - NODE_HEIGHT / 2 },
+      data: { ...skill, colors },
+    }
+  })
+
+  return { nodes, edges }
+}
+
+const nodeTypes = { skillNode: SkillNode }
+
+export default function SkillTreeScreen() {
+  const skills = useMemo(() => yaml.load(skillsRaw), [])
+  const { nodes: initialNodes, edges: initialEdges } = useMemo(
+    () => buildGraph(skills),
+    [skills]
+  )
+
+  const [nodes, , onNodesChange] = useNodesState(initialNodes)
+  const [edges, , onEdgesChange] = useEdgesState(initialEdges)
+  const [selected, setSelected] = useState(null)
+
+  const onNodeClick = useCallback(
+    (_, node) => setSelected(node.data),
+    []
+  )
+
+  const onPaneClick = useCallback(() => setSelected(null), [])
+
+  const minimapColor = useCallback(
+    (node) => node.data?.colors?.minimap ?? "#a1abd7",
+    []
+  )
+
+  return (
+    <div className="h-screen w-screen flex flex-col bg-background">
+      <header className="flex items-center gap-4 px-6 py-3 border-b border-outline-variant/30">
+        <a
+          href="/"
+          className="text-primary hover:text-primary-dim transition-colors text-sm font-medium"
+        >
+          ← Accueil
+        </a>
+        <h1 className="font-headline text-lg font-bold text-on-background">
+          Arbre de compétences
+        </h1>
+        <Legend />
+      </header>
+
+      <div className="flex-1 relative">
+        <ReactFlow
+          nodes={nodes}
+          edges={edges}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
+          onNodeClick={onNodeClick}
+          onPaneClick={onPaneClick}
+          nodeTypes={nodeTypes}
+          fitView
+          fitViewOptions={{ padding: 0.15 }}
+          minZoom={0.1}
+          maxZoom={2}
+          proOptions={{ hideAttribution: true }}
+        >
+          <Background color="#a1abd7" gap={24} size={1} />
+          <Controls position="bottom-right" />
+          <MiniMap
+            nodeColor={minimapColor}
+            maskColor="rgba(244, 242, 255, 0.7)"
+            position="bottom-left"
+          />
+        </ReactFlow>
+
+        {selected && <DetailPanel skill={selected} onClose={() => setSelected(null)} />}
+      </div>
+    </div>
+  )
+}
+
+function Legend() {
+  return (
+    <div className="ml-auto flex items-center gap-3">
+      {Object.entries(GRADE_COLORS).map(([grade, colors]) => (
+        <div key={grade} className="flex items-center gap-1.5 text-xs">
+          <span
+            className="w-3 h-3 rounded-sm"
+            style={{ backgroundColor: colors.bg, border: `1.5px solid ${colors.border}` }}
+          />
+          <span className="text-on-surface-variant">{grade}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function DetailPanel({ skill, onClose }) {
+  const colors = GRADE_COLORS[skill.grade]
+  return (
+    <div className="absolute top-4 right-4 w-80 glass-card ghost-border shadow-ambient rounded-xl p-5 z-50">
+      <div className="flex items-start justify-between mb-3">
+        <span
+          className="text-xs font-medium px-2 py-0.5 rounded-full"
+          style={{ backgroundColor: colors.bg, color: colors.text }}
+        >
+          {skill.grade} — {levelDescriptions[skill.grade]}
+        </span>
+        <button
+          onClick={onClose}
+          className="text-on-surface-variant hover:text-on-surface text-lg leading-none"
+        >
+          ×
+        </button>
+      </div>
+      <h3 className="font-headline font-bold text-on-background text-sm mb-1">
+        {skill.label}
+      </h3>
+      <p className="text-xs text-on-surface-variant leading-relaxed mb-3">
+        {skill.description}
+      </p>
+      <div className="flex items-center gap-4 text-xs text-on-surface-variant">
+        <span>Seuil : {skill.mastery_threshold} réponses</span>
+        <span>Prérequis : {skill.prerequisites.length}</span>
+      </div>
+      {skill.prerequisites.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-1">
+          {skill.prerequisites.map((id) => (
+            <code
+              key={id}
+              className="text-[10px] bg-surface-container px-1.5 py-0.5 rounded text-on-surface-variant"
+            >
+              {id}
+            </code>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ui/SkillNode.jsx
+++ b/src/components/ui/SkillNode.jsx
@@ -1,33 +1,63 @@
 import { Handle, Position } from "@xyflow/react"
 
+const STATUS_STYLES = {
+  completed: {
+    ring: "solid",
+    ringWidth: 2,
+    opacity: 1,
+  },
+  in_progress: {
+    ring: "dashed",
+    ringWidth: 3,
+    opacity: 1,
+  },
+  locked: {
+    ring: "solid",
+    ringWidth: 2,
+    opacity: 0.6,
+  },
+}
+
 export default function SkillNode({ data }) {
-  const { label, grade, colors } = data
+  const { label, colors, icon, status, isNext } = data
+  const styles = STATUS_STYLES[status]
+  const locked = status === "locked"
+  const bg = locked ? "#edeef5" : colors.bg
+  const border = locked ? "#b0b5c9" : colors.border
+  const textColor = locked ? "#8890a8" : colors.text
 
   return (
-    <div
-      className="rounded-lg px-3 py-2 text-center cursor-pointer shadow-ambient-sm transition-shadow hover:shadow-ambient"
-      style={{
-        width: 220,
-        backgroundColor: colors.bg,
-        border: `1.5px solid ${colors.border}`,
-      }}
-    >
-      <div className="flex items-center gap-1.5">
+    <div className="relative flex flex-col items-center" style={{ width: 140 }}>
+      {isNext && (
+        <div className="absolute -top-7 px-2.5 py-1 rounded-full text-[10px] font-bold bg-tertiary text-on-tertiary shadow-ambient-sm whitespace-nowrap z-10">
+          Prochaine étape
+        </div>
+      )}
+      <div
+        className="flex items-center justify-center rounded-full cursor-pointer shadow-ambient-sm transition-transform hover:scale-105"
+        style={{
+          width: 92,
+          height: 92,
+          background: bg,
+          border: `${styles.ringWidth}px ${styles.ring} ${border}`,
+          opacity: styles.opacity,
+        }}
+      >
         <span
-          className="text-[10px] font-bold shrink-0 px-1 py-px rounded"
-          style={{ backgroundColor: colors.border, color: colors.bg }}
+          className="material-symbols-outlined"
+          style={{ color: textColor, fontSize: 38 }}
         >
-          {grade}
-        </span>
-        <span
-          className="text-xs font-medium truncate"
-          style={{ color: colors.text }}
-        >
-          {label}
+          {icon}
         </span>
       </div>
-      <Handle type="target" position={Position.Top} className="!bg-outline !w-2 !h-2" />
-      <Handle type="source" position={Position.Bottom} className="!bg-outline !w-2 !h-2" />
+      <div
+        className="mt-2 text-center text-[11px] font-semibold leading-tight px-1"
+        style={{ color: locked ? "#8890a8" : "#1a1f3a" }}
+      >
+        {label}
+      </div>
+      <Handle type="target" position={Position.Top} className="!opacity-0 !bg-transparent" />
+      <Handle type="source" position={Position.Bottom} className="!opacity-0 !bg-transparent" />
     </div>
   )
 }

--- a/src/components/ui/SkillNode.jsx
+++ b/src/components/ui/SkillNode.jsx
@@ -1,0 +1,33 @@
+import { Handle, Position } from "@xyflow/react"
+
+export default function SkillNode({ data }) {
+  const { label, grade, colors } = data
+
+  return (
+    <div
+      className="rounded-lg px-3 py-2 text-center cursor-pointer shadow-ambient-sm transition-shadow hover:shadow-ambient"
+      style={{
+        width: 220,
+        backgroundColor: colors.bg,
+        border: `1.5px solid ${colors.border}`,
+      }}
+    >
+      <div className="flex items-center gap-1.5">
+        <span
+          className="text-[10px] font-bold shrink-0 px-1 py-px rounded"
+          style={{ backgroundColor: colors.border, color: colors.bg }}
+        >
+          {grade}
+        </span>
+        <span
+          className="text-xs font-medium truncate"
+          style={{ color: colors.text }}
+        >
+          {label}
+        </span>
+      </div>
+      <Handle type="target" position={Position.Top} className="!bg-outline !w-2 !h-2" />
+      <Handle type="source" position={Position.Bottom} className="!bg-outline !w-2 !h-2" />
+    </div>
+  )
+}

--- a/src/lib/skillTreeLayout.js
+++ b/src/lib/skillTreeLayout.js
@@ -1,0 +1,238 @@
+import { MarkerType } from "@xyflow/react"
+
+export const GRADES = ["P1", "P2", "P3", "P4", "P5", "P6"]
+
+export const GRADE_COLORS = {
+  P1: { bg: "#c9f7e3", border: "#00694b", text: "#00694b", minimap: "#00694b" },
+  P2: { bg: "#ffe89a", border: "#8a6d00", text: "#8a6d00", minimap: "#8a6d00" },
+  P3: { bg: "#b8d1ff", border: "#0059b6", text: "#0059b6", minimap: "#0059b6" },
+  P4: { bg: "#e9d2ff", border: "#7b3d96", text: "#7b3d96", minimap: "#7b3d96" },
+  P5: { bg: "#ffd4b8", border: "#b64600", text: "#b64600", minimap: "#b64600" },
+  P6: { bg: "#dde2ff", border: "#505a81", text: "#505a81", minimap: "#505a81" },
+}
+
+const ICON_BY_PREFIX = [
+  ["num_", "123"],
+  ["add_", "add"],
+  ["soustr_", "remove"],
+  ["mult_", "close"],
+  ["div_", "percent"],
+  ["prop_", "swap_horiz"],
+  ["cm_", "psychology"],
+  ["ce_", "edit_note"],
+  ["estimation_", "query_stats"],
+]
+
+function iconFor(id) {
+  for (const [prefix, icon] of ICON_BY_PREFIX) {
+    if (id.startsWith(prefix)) return icon
+  }
+  return "school"
+}
+
+function mockStatus(skill) {
+  if (skill.grade === "P1") return "completed"
+  if (skill.grade === "P2") return "in_progress"
+  return "locked"
+}
+
+export const NODE_WIDTH = 140
+export const NODE_GAP_X = 24
+export const SUBROW_HEIGHT = 170
+export const BAND_GAP = 60
+export const BAND_PAD_TOP = 40
+const LANE_LABEL_X = -180
+
+function computeDepth(skills) {
+  const byId = new Map(skills.map((s) => [s.id, s]))
+  const depth = new Map()
+  const visit = (id) => {
+    if (depth.has(id)) return depth.get(id)
+    const s = byId.get(id)
+    if (!s || s.prerequisites.length === 0) {
+      depth.set(id, 0)
+      return 0
+    }
+    depth.set(id, 0)
+    const d = 1 + Math.max(...s.prerequisites.map(visit), -1)
+    depth.set(id, d)
+    return d
+  }
+  for (const s of skills) visit(s.id)
+  return depth
+}
+
+function orderByBarycenter(skills, positions, successors, useSuccessors) {
+  const withBary = skills.map((s) => {
+    const neighbors = useSuccessors
+      ? [...s.prerequisites, ...(successors.get(s.id) ?? [])]
+      : s.prerequisites
+    const xs = neighbors.map((id) => positions.get(id)?.x).filter((x) => x !== undefined)
+    const bary = xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : Number.POSITIVE_INFINITY
+    return { s, bary }
+  })
+  withBary.sort((a, b) => {
+    if (a.bary === Number.POSITIVE_INFINITY && b.bary === Number.POSITIVE_INFINITY) {
+      return a.s.id.localeCompare(b.s.id)
+    }
+    if (a.bary === Number.POSITIVE_INFINITY) return 1
+    if (b.bary === Number.POSITIVE_INFINITY) return -1
+    return a.bary - b.bary
+  })
+  return withBary.map(({ s }) => s)
+}
+
+export function buildGraph(skills, nextId) {
+  const byGrade = new Map(GRADES.map((g) => [g, []]))
+  for (const s of skills) {
+    if (byGrade.has(s.grade)) byGrade.get(s.grade).push(s)
+  }
+
+  const successors = new Map()
+  for (const s of skills) {
+    for (const p of s.prerequisites) {
+      if (!successors.has(p)) successors.set(p, [])
+      successors.get(p).push(s.id)
+    }
+  }
+
+  const depth = computeDepth(skills)
+
+  const gradeInfo = new Map()
+  for (const grade of GRADES) {
+    const gs = byGrade.get(grade)
+    if (!gs.length) {
+      gradeInfo.set(grade, { rows: new Map(), rowCount: 0 })
+      continue
+    }
+    const depths = gs.map((s) => depth.get(s.id))
+    const minD = Math.min(...depths)
+    const maxD = Math.max(...depths)
+    const rows = new Map()
+    for (const s of gs) {
+      const r = depth.get(s.id) - minD
+      if (!rows.has(r)) rows.set(r, [])
+      rows.get(r).push(s)
+    }
+    gradeInfo.set(grade, { minD, rows, rowCount: maxD - minD + 1 })
+  }
+
+  const gradeYStart = new Map()
+  const gradeYEnd = new Map()
+  let yAcc = BAND_PAD_TOP
+  for (const grade of GRADES) {
+    gradeYStart.set(grade, yAcc)
+    const info = gradeInfo.get(grade)
+    const h = Math.max(info.rowCount, 1) * SUBROW_HEIGHT
+    yAcc += h
+    gradeYEnd.set(grade, yAcc)
+    yAcc += BAND_GAP
+  }
+
+  const positions = new Map()
+  const placeRow = (rowSkills, grade, r, useSucc) => {
+    const ordered = orderByBarycenter(rowSkills, positions, successors, useSucc)
+    ordered.forEach((s, i) => {
+      positions.set(s.id, {
+        x: i * (NODE_WIDTH + NODE_GAP_X),
+        y: gradeYStart.get(grade) + r * SUBROW_HEIGHT,
+      })
+    })
+  }
+
+  for (const grade of GRADES) {
+    const info = gradeInfo.get(grade)
+    for (let r = 0; r < info.rowCount; r++) {
+      placeRow(info.rows.get(r) ?? [], grade, r, false)
+    }
+  }
+  for (let pass = 0; pass < 3; pass++) {
+    for (const grade of [...GRADES].reverse()) {
+      const info = gradeInfo.get(grade)
+      for (let r = info.rowCount - 1; r >= 0; r--) {
+        placeRow(info.rows.get(r) ?? [], grade, r, true)
+      }
+    }
+    for (const grade of GRADES) {
+      const info = gradeInfo.get(grade)
+      for (let r = 0; r < info.rowCount; r++) {
+        placeRow(info.rows.get(r) ?? [], grade, r, true)
+      }
+    }
+  }
+
+  const allX = [...positions.values()].map((p) => p.x)
+  const maxX = allX.length ? Math.max(...allX) : 0
+
+  const nodes = skills.map((s) => ({
+    id: s.id,
+    type: "skillNode",
+    position: positions.get(s.id),
+    data: {
+      ...s,
+      colors: GRADE_COLORS[s.grade],
+      icon: iconFor(s.id),
+      status: mockStatus(s),
+      isNext: s.id === nextId,
+    },
+    draggable: false,
+  }))
+
+  const edges = skills.flatMap((s) =>
+    s.prerequisites.map((pid) => ({
+      id: `${pid}->${s.id}`,
+      source: pid,
+      target: s.id,
+      type: "smoothstep",
+      style: { stroke: "#c2c7dd", strokeWidth: 1.5, strokeDasharray: "6 6" },
+      markerEnd: { type: MarkerType.ArrowClosed, color: "#c2c7dd", width: 14, height: 14 },
+    }))
+  )
+
+  const laneNodes = GRADES.map((grade) => {
+    const yStart = gradeYStart.get(grade)
+    const yEnd = gradeYEnd.get(grade)
+    return {
+      id: `lane-${grade}`,
+      type: "laneLabel",
+      position: { x: LANE_LABEL_X, y: yStart - 20 },
+      data: {
+        grade,
+        colors: GRADE_COLORS[grade],
+        width: maxX + NODE_WIDTH + 220,
+        height: yEnd - yStart + 40,
+      },
+      draggable: false,
+      selectable: false,
+    }
+  })
+
+  return { nodes: [...laneNodes, ...nodes], edges, successors }
+}
+
+export function collectRelated(id, skills, successors) {
+  const byId = new Map(skills.map((s) => [s.id, s]))
+  const ancestors = new Set()
+  const stackA = [id]
+  while (stackA.length) {
+    const cur = stackA.pop()
+    for (const p of byId.get(cur)?.prerequisites ?? []) {
+      if (!ancestors.has(p)) {
+        ancestors.add(p)
+        stackA.push(p)
+      }
+    }
+  }
+  const descendants = new Set()
+  const stackD = [id]
+  while (stackD.length) {
+    const cur = stackD.pop()
+    for (const c of successors.get(cur) ?? []) {
+      if (!descendants.has(c)) {
+        descendants.add(c)
+        stackD.push(c)
+      }
+    }
+  }
+  return { ancestors, descendants }
+}


### PR DESCRIPTION
## Summary
- Grade swimlanes top-to-bottom (P1 → P6) with depth-based sub-rows inside each band so skills without prerequisites sit at the top of their year and downstream skills stack below.
- Circular skill nodes with Material icons, mocked status (completed / in_progress / locked) and a "Prochaine étape" chip on the next skill.
- Improved navigation: grade filter pills, search input, status legend, dashed arrow edges, scroll-to-pan, click-to-focus on prerequisites (upstream only).
- Layout logic extracted to `src/lib/skillTreeLayout.js` to keep the screen component under 400 lines.

## Test plan
- [ ] `npm run dev` → open `/skill-tree`, verify swimlanes stack P1 → P6 with sub-rows
- [ ] Click a skill: only it and its prerequisites stay visible, downstream skills are dimmed
- [ ] Grade pills filter highlight; search dims non-matching skills
- [ ] Status legend reflects node styles (solid / dashed / locked)
- [ ] Arrows point from prerequisite to dependent skill
- [ ] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)