### PR TITLE
chore(wiki): ignore raw/ contents in git and for Claude reads

### DIFF
--- a/.claude/skills/pedagogia-wiki/SKILL.md
+++ b/.claude/skills/pedagogia-wiki/SKILL.md
@@ -37,6 +37,8 @@ Then skim `vault/wiki/index.md` to see what's already in the wiki. This avoids c
 
 Trigger phrases: *"ingest this"*, *"add to the wiki"*, *"add to the knowledge base"*, *"file this"*, *"process this source"*, or the user simply dropping a file into `raw/` and asking you to look at it.
 
+`vault/raw/` is **gitignored and potentially heavy** (PDFs, image dumps, long transcripts). Don't enumerate or grep it to browse — only read the specific file the user points at. If you don't know the filename, ask the user instead of listing the directory.
+
 Before writing anything, read the source fully and **discuss takeaways in chat**. The user is interactive and wants to steer emphasis before pages are committed. Filing in silence is a failure mode — the synthesis is where the human adds value.
 
 Then the standard ingest sequence (detail in the wiki's `CLAUDE.md`):

--- a/vault/.gitignore
+++ b/vault/.gitignore
@@ -2,3 +2,9 @@
 .obsidian/workspace-mobile.json
 .obsidian/workspaces.json
 .obsidian/cache
+
+raw/*
+!raw/.gitkeep
+!raw/assets/
+raw/assets/*
+!raw/assets/.gitkeep

--- a/vault/CLAUDE.md
+++ b/vault/CLAUDE.md
@@ -39,6 +39,7 @@ Rules:
 - **Never modify `raw/`.** Source of truth. Read-only for you.
 - **You own `wiki/` entirely.** Create, update, rename, delete pages as needed.
 - Unsure where a page belongs? `entities/` for proper nouns (a person, a curriculum, a tool), `concepts/` for common nouns (mastery learning, DAG, spaced repetition), `questions/` for analyses/comparisons the user asked for.
+- **`raw/` is gitignored and can be heavy** (PDFs, image dumps, long transcripts). Don't enumerate or grep `raw/` to explore it. Only read the specific file the user points at when they ask to ingest. If you need a filename, ask the user rather than listing the directory.
 
 ## Page conventions
 


### PR DESCRIPTION
## Summary
- Gitignore everything under `vault/raw/` (keeping `.gitkeep` markers).
- Add matching guidance in `vault/CLAUDE.md` and the `pedagogia-wiki` skill: don't enumerate or grep `raw/` — only read the specific file the user points at.

Rationale: raw sources can be heavy (PDFs, transcripts, image dumps). Tracking them would bloat the repo; letting Claude browse them would burn context.

## Test plan
- [ ] `git status` after dropping a PDF into `vault/raw/` shows no change.
- [ ] The `.gitkeep` files still appear in `git ls-files vault/raw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)