### PR TITLE
Skill tree with real mastery data and centered layout

### DIFF
--- a/backend/apps/students/services/grade_seeding.py
+++ b/backend/apps/students/services/grade_seeding.py
@@ -1,0 +1,28 @@
+from apps.skills.models import Skill
+from apps.students.models import Student, StudentSkillState
+
+
+def seed_prior_grade_mastery(student: Student) -> int:
+    """Mark every skill from strictly lower grades as mastered. Called on student creation."""
+    prior_skills = Skill.objects.filter(grade__lt=student.grade)
+    if not prior_skills.exists():
+        return 0
+    existing = set(
+        StudentSkillState.objects.filter(student=student, skill__in=prior_skills).values_list(
+            "skill_id", flat=True
+        )
+    )
+    rows = [
+        StudentSkillState(
+            student=student,
+            skill=skill,
+            status=StudentSkillState.MASTERED,
+            mastery_level=1.0,
+            consecutive_correct=skill.mastery_threshold,
+            total_attempts=skill.mastery_threshold,
+        )
+        for skill in prior_skills
+        if skill.id not in existing
+    ]
+    StudentSkillState.objects.bulk_create(rows)
+    return len(rows)

--- a/backend/apps/students/views.py
+++ b/backend/apps/students/views.py
@@ -1,9 +1,13 @@
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
 from apps.common.permissions import IsOwner
+from apps.skills.models import Skill
 
-from .models import Student
+from .models import Student, StudentSkillState
 from .serializers import StudentSerializer
+from .services.grade_seeding import seed_prior_grade_mastery
 
 
 class StudentViewSet(ModelViewSet):
@@ -17,4 +21,27 @@ class StudentViewSet(ModelViewSet):
         return Student.objects.filter(user=user)
 
     def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
+        student = serializer.save(user=self.request.user)
+        seed_prior_grade_mastery(student)
+
+    @action(detail=True, methods=["get"], url_path="skill-tree")
+    def skill_tree(self, request, pk=None):
+        """Per-skill mastery snapshot for this student (one row per seeded skill)."""
+        student = self.get_object()
+        skills = Skill.objects.only("id").order_by("id")
+        states = {s.skill_id: s for s in StudentSkillState.objects.filter(student=student)}
+        payload = []
+        for skill in skills:
+            state = states.get(skill.id)
+            payload.append(
+                {
+                    "skill_id": skill.id,
+                    "status": state.status if state else StudentSkillState.NOT_STARTED,
+                    "mastery_level": state.mastery_level if state else 0.0,
+                    "total_attempts": state.total_attempts if state else 0,
+                    "consecutive_correct": state.consecutive_correct if state else 0,
+                    "last_practiced_at": state.last_practiced_at if state else None,
+                    "next_review_at": state.next_review_at if state else None,
+                }
+            )
+        return Response(payload)

--- a/backend/tests/test_students_api.py
+++ b/backend/tests/test_students_api.py
@@ -74,3 +74,89 @@ def test_unauthenticated_cannot_list_or_create(api):
     assert api.get("/api/students/").status_code in (401, 403)
     res = api.post("/api/students/", {"display_name": "X", "grade": "P1"}, format="json")
     assert res.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_skill_tree_endpoint_returns_all_skills(auth_client):
+    from apps.skills.models import Skill
+
+    student = auth_client.post(
+        "/api/students/", {"display_name": "A", "grade": "P1"}, format="json"
+    ).json()
+
+    res = auth_client.get(f"/api/students/{student['id']}/skill-tree/")
+    assert res.status_code == 200
+    payload = res.json()
+    assert len(payload) == Skill.objects.count()
+    row = payload[0]
+    assert set(row.keys()) == {
+        "skill_id",
+        "status",
+        "mastery_level",
+        "total_attempts",
+        "consecutive_correct",
+        "last_practiced_at",
+        "next_review_at",
+    }
+    assert all(r["status"] == "not_started" for r in payload)
+    assert all(r["mastery_level"] == 0.0 for r in payload)
+
+
+@pytest.mark.django_db
+def test_skill_tree_reflects_mastery(auth_client):
+    from apps.skills.models import Skill
+    from apps.students.models import Student
+    from apps.students.services.mastery import update_mastery
+
+    student = auth_client.post(
+        "/api/students/", {"display_name": "A", "grade": "P1"}, format="json"
+    ).json()
+    skill = Skill.objects.get(id="add_avec_retenue_20")
+    update_mastery(Student.objects.get(id=student["id"]), skill, is_correct=True)
+
+    res = auth_client.get(f"/api/students/{student['id']}/skill-tree/")
+    row = next(r for r in res.json() if r["skill_id"] == "add_avec_retenue_20")
+    assert row["status"] == "in_progress"
+    assert row["total_attempts"] == 1
+    assert row["consecutive_correct"] == 1
+    assert row["mastery_level"] > 0
+    assert row["last_practiced_at"] is not None
+
+
+@pytest.mark.django_db
+def test_skill_tree_scoped_to_owner(auth_client, other_user, api):
+    mine = auth_client.post(
+        "/api/students/", {"display_name": "Mine", "grade": "P1"}, format="json"
+    ).json()
+    api.force_authenticate(other_user)
+    res = api.get(f"/api/students/{mine['id']}/skill-tree/")
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+def test_new_p5_student_has_prior_grades_mastered(auth_client):
+    from apps.skills.models import Skill
+
+    student = auth_client.post(
+        "/api/students/", {"display_name": "Aïda", "grade": "P5"}, format="json"
+    ).json()
+    res = auth_client.get(f"/api/students/{student['id']}/skill-tree/")
+    by_id = {r["skill_id"]: r for r in res.json()}
+
+    prior_ids = list(Skill.objects.filter(grade__lt="P5").values_list("id", flat=True))
+    current_ids = list(Skill.objects.filter(grade__gte="P5").values_list("id", flat=True))
+    assert prior_ids, "expected prior-grade skills to exist"
+    for sid in prior_ids:
+        assert by_id[sid]["status"] == "mastered"
+        assert by_id[sid]["mastery_level"] == 1.0
+    for sid in current_ids:
+        assert by_id[sid]["status"] == "not_started"
+
+
+@pytest.mark.django_db
+def test_new_p1_student_has_nothing_seeded(auth_client):
+    student = auth_client.post(
+        "/api/students/", {"display_name": "Bébé", "grade": "P1"}, format="json"
+    ).json()
+    res = auth_client.get(f"/api/students/{student['id']}/skill-tree/")
+    assert all(r["status"] == "not_started" for r in res.json())

--- a/frontend/e2e/skilltree-preview.spec.js
+++ b/frontend/e2e/skilltree-preview.spec.js
@@ -1,0 +1,87 @@
+import { test, expect } from "@playwright/test"
+import { mkdirSync, writeFileSync, rmSync } from "node:fs"
+import { execSync } from "node:child_process"
+
+const SHOTS = "e2e/screenshots"
+mkdirSync(SHOTS, { recursive: true })
+
+test("skill tree page renders for a logged-in student", async ({ page }) => {
+  const email = `tree-${Date.now()}@example.com`
+
+  await page.goto("/register")
+  await page.getByTestId("register-name").fill("Camille")
+  await page.getByTestId("register-email").fill(email)
+  await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-submit").click()
+  await expect(page).toHaveURL(/\/children/)
+
+  await page.getByTestId("child-name").fill("Noé")
+  await page.getByTestId("child-grade").selectOption("P3")
+  await page.getByTestId("child-add").click()
+  await expect(page.getByTestId("children-list").locator("[data-testid^='child-']"))
+    .toHaveCount(1)
+  await page.getByTestId("children-list").locator("button").first().click()
+  await expect(page).toHaveURL(/\/$|\/welcome/)
+
+  // Seed mastery if a local docker stack is reachable — harmless if it isn't.
+  try {
+    const studentId = await page.evaluate(async () => {
+      const res = await fetch("/api/auth/user/", { credentials: "include" })
+      const data = await res.json()
+      return data.children?.[0]?.id
+    })
+    if (studentId) {
+      const script = [
+        "import os, sys, django",
+        "sys.path.insert(0, '/app')",
+        "os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'pedagogia.settings.dev')",
+        "django.setup()",
+        "from apps.students.models import Student, StudentSkillState",
+        "from apps.skills.models import Skill",
+        "from django.utils import timezone",
+        `s = Student.objects.get(id='${studentId}')`,
+        "seeds = {",
+        "  'add_avec_retenue_1000': ('in_progress', 0.55, 4, 2),",
+        "  'soustr_avec_emprunt_1000': ('in_progress', 0.3, 2, 1),",
+        "  'mult_tables_5': ('needs_review', 0.4, 3, 0),",
+        "  'mult_tables_2': ('mastered', 1.0, 6, 6),",
+        "}",
+        "for sid, (st, lvl, att, cc) in seeds.items():",
+        "    sk = Skill.objects.filter(id=sid).first()",
+        "    if not sk: continue",
+        "    row, _ = StudentSkillState.objects.get_or_create(student=s, skill=sk)",
+        "    row.status = st; row.mastery_level = lvl",
+        "    row.total_attempts = att; row.consecutive_correct = cc",
+        "    row.last_practiced_at = timezone.now(); row.save()"
+      ].join("\n")
+      const repoRoot = process.cwd().replace(/\/frontend$/, "")
+      const tmp = `${repoRoot}/.skilltree-seed.py`
+      writeFileSync(tmp, script)
+      try {
+        execSync(
+          "docker compose cp .skilltree-seed.py backend:/tmp/seed.py && docker compose exec -T backend uv run python /tmp/seed.py",
+          { cwd: repoRoot, shell: "/bin/bash", stdio: "pipe" }
+        )
+      } finally {
+        rmSync(tmp, { force: true })
+      }
+    }
+  } catch {
+    // no docker / no backend container — skip seeding silently
+  }
+
+  await page.goto("/skill-tree")
+  await expect(page.getByRole("heading", { name: /carte des espèces/i })).toBeVisible()
+  await expect(page.getByRole("button", { name: /vue d'ensemble/i })).toBeVisible()
+  await page.waitForTimeout(3000)
+  await page.screenshot({ path: `${SHOTS}/skilltree-desktop.png`, fullPage: false })
+
+  // Hover an "en cours" skill to see its same-year prereqs light up.
+  const inProgress = page.locator(".specimen-croissance").first()
+  if (await inProgress.count()) {
+    await inProgress.scrollIntoViewIfNeeded()
+    await inProgress.hover()
+    await page.waitForTimeout(600)
+    await page.screenshot({ path: `${SHOTS}/skilltree-hover-prereqs.png`, fullPage: false })
+  }
+})

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -151,6 +151,36 @@
   box-shadow: 0 1px 0 rgba(43, 58, 46, 0.03), 0 8px 18px -14px rgba(63, 111, 74, 0.25);
 }
 
+/* Croissance breath — "en cours" skills visibly alive */
+@keyframes croissance-breath {
+  0%, 100% {
+    box-shadow: 0 0 0 2px #c7e0b5, 0 8px 18px -14px rgba(63, 111, 74, 0.25);
+  }
+  50% {
+    box-shadow: 0 0 0 5px #c7e0b5, 0 14px 28px -10px rgba(63, 111, 74, 0.45);
+  }
+}
+.specimen-croissance {
+  animation: croissance-breath 2.6s ease-in-out infinite;
+}
+
+/* Prereq-of-hover glow ring — appears on same-year prereqs when hovering a node */
+@keyframes prereq-glow {
+  0%, 100% {
+    box-shadow:
+      0 0 0 2px rgba(111, 162, 116, 0.55),
+      0 0 18px rgba(111, 162, 116, 0.35);
+  }
+  50% {
+    box-shadow:
+      0 0 0 4px rgba(111, 162, 116, 0.85),
+      0 0 28px rgba(111, 162, 116, 0.6);
+  }
+}
+.prereq-glow {
+  animation: prereq-glow 1.3s ease-in-out infinite;
+}
+
 /* Pill-shaped nav link */
 .navlink {
   padding: 9px 14px;

--- a/frontend/src/api/students.js
+++ b/frontend/src/api/students.js
@@ -1,0 +1,5 @@
+import { api } from "./client"
+
+export const studentsApi = {
+  skillTree: (studentId) => api.get(`/students/${studentId}/skill-tree/`)
+}

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -1,31 +1,46 @@
-import { useState, useCallback, useEffect, useMemo } from "react"
+import { useState, useCallback, useEffect, useMemo, useRef } from "react"
 import {
   ReactFlow,
+  ReactFlowProvider,
   Background,
   Controls,
   MiniMap,
-  MarkerType,
   useNodesState,
   useEdgesState,
+  useReactFlow,
 } from "@xyflow/react"
 import "@xyflow/react/dist/style.css"
 import { useNavigate } from "react-router"
+import { useQuery } from "@tanstack/react-query"
 import { api } from "../../api/client"
+import { useAuthStore } from "../../stores/authStore"
+import { useSkillTree } from "../../hooks/useSkillTree"
 import SkillNode from "../ui/SkillNode"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
 import { LatinLabel } from "../ui/Heading"
 import { levelDescriptions, levelLatin, levelVernacular } from "../../lib/constants"
-import { GRADES, GRADE_COLORS, buildGraph, collectRelated } from "../../lib/skillTreeLayout"
+import { GRADES, buildGraph } from "../../lib/skillTreeLayout"
+import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
+
+const EMPTY_SET = new Set()
 
 function LaneLabel({ data }) {
   const { grade, colors, width, height } = data
   return (
-    <div className="pointer-events-none flex items-center" style={{ width, height }}>
+    <div className="pointer-events-none relative" style={{ width, height }}>
       <div
-        className="tag px-4 py-4 shrink-0"
-        style={{ borderLeft: `3px solid ${colors.border}`, width: 130 }}
+        className="absolute inset-0 rounded-2xl"
+        style={{ backgroundColor: colors.bg, opacity: 0.45 }}
+      />
+      <div
+        className="absolute left-0 top-0 bottom-0 w-1.5 rounded-l-2xl"
+        style={{ backgroundColor: colors.border, opacity: 0.55 }}
+      />
+      <div
+        className="tag px-4 py-4 absolute top-1/2 -translate-y-1/2"
+        style={{ borderLeft: `3px solid ${colors.border}`, width: 130, left: 16 }}
       >
         <div className="font-display font-semibold text-xl text-bark">{grade}</div>
         <div className="latin text-[10px] mt-0.5">{levelLatin[grade]}</div>
@@ -33,38 +48,84 @@ function LaneLabel({ data }) {
           {levelVernacular[grade]}
         </div>
       </div>
-      <div
-        className="flex-1 h-[80%] ml-6 rounded-xl"
-        style={{ backgroundColor: colors.bg, opacity: 0.2 }}
-      />
     </div>
   )
 }
 
 const nodeTypes = { skillNode: SkillNode, laneLabel: LaneLabel }
 
-export default function SkillTreeScreen() {
+function pickFocusSkill(skills, stateById) {
+  const rank = { in_progress: 2, needs_review: 1 }
+  let best = null
+  for (const s of skills) {
+    const st = stateById.get(s.id)
+    if (!st) continue
+    const r = rank[st.status] ?? 0
+    if (!r) continue
+    if (!best || r > best.r || (r === best.r && st.mastery_level > best.m)) {
+      best = { id: s.id, r, m: st.mastery_level }
+    }
+  }
+  return best?.id ?? null
+}
+
+function SkillTreeInner({ skills, skillTreeData, isLoading }) {
   const navigate = useNavigate()
-  const [skills, setSkills] = useState(null)
+  const { fitView } = useReactFlow()
 
-  useEffect(() => {
-    api.get("/skills/").then((data) =>
-      setSkills(data.map((s) => ({ ...s, prerequisites: s.prerequisite_ids })))
-    )
-  }, [])
-
-  const nextId = useMemo(
-    () => skills?.find((s) => s.grade === "P2")?.id ?? null,
-    [skills]
+  const children = useAuthStore((s) => s.children)
+  const selectedChildId = useAuthStore((s) => s.selectedChildId)
+  const currentChild = useMemo(
+    () => children.find((c) => c.id === selectedChildId) ?? null,
+    [children, selectedChildId]
   )
 
-  const { nodes: initialNodes, edges: initialEdges, successors } = useMemo(
+  const stateById = useMemo(() => {
+    const map = new Map()
+    for (const row of skillTreeData ?? []) map.set(row.skill_id, row)
+    return map
+  }, [skillTreeData])
+
+  const focusId = useMemo(
+    () => (skills ? pickFocusSkill(skills, stateById) : null),
+    [skills, stateById]
+  )
+
+  const { nodes: initialNodes, edges: initialEdges, bounds } = useMemo(
     () =>
       skills
-        ? buildGraph(skills, nextId)
-        : { nodes: [], edges: [], successors: new Map() },
-    [skills, nextId]
+        ? buildGraph(skills, focusId, stateById)
+        : { nodes: [], edges: [], bounds: null },
+    [skills, focusId, stateById]
   )
+
+  const translateExtent = useMemo(() => {
+    if (!bounds) return undefined
+    const pad = 80
+    return [
+      [bounds.minX - pad, bounds.minY - pad],
+      [bounds.maxX + pad, bounds.maxY + pad],
+    ]
+  }, [bounds])
+
+  const flowRef = useRef(null)
+  const minZoomRef = useRef(0.5)
+  const [minZoom, setMinZoom] = useState(0.5)
+  useEffect(() => {
+    if (!bounds || !flowRef.current) return
+    const update = () => {
+      const w = flowRef.current?.clientWidth ?? 0
+      const treeW = bounds.maxX - bounds.minX
+      if (!w || !treeW) return
+      const next = Math.max(0.4, Math.min(1.1, w / treeW))
+      minZoomRef.current = next
+      setMinZoom(next)
+    }
+    update()
+    const obs = new ResizeObserver(update)
+    obs.observe(flowRef.current)
+    return () => obs.disconnect()
+  }, [bounds])
 
   const [nodes, setNodes, onNodesChange] = useNodesState(initialNodes)
   const [edges, setEdges, onEdgesChange] = useEdgesState(initialEdges)
@@ -73,13 +134,44 @@ export default function SkillTreeScreen() {
     setNodes(initialNodes)
     setEdges(initialEdges)
   }, [initialNodes, initialEdges, setNodes, setEdges])
+
   const [selected, setSelected] = useState(null)
   const [query, setQuery] = useState("")
+  const [searchOpen, setSearchOpen] = useState(false)
   const [gradeFilter, setGradeFilter] = useState(null)
+  const hoverContext = useMemo(() => ({ hoveredId: null, prereqs: EMPTY_SET }), [])
 
-  const applyHighlight = useCallback(
-    (focusId, q, grade) => {
-      const related = focusId ? collectRelated(focusId, skills, successors) : null
+  const centeredRef = useRef(false)
+  const [rfReady, setRfReady] = useState(false)
+  const onInit = useCallback(() => setRfReady(true), [])
+
+  useEffect(() => {
+    if (centeredRef.current || !rfReady || !initialNodes.length) return
+    const skillNodes = initialNodes.filter((n) => n.type === "skillNode")
+    if (!skillNodes.length) return
+    const focus = skillNodes.find((n) => n.id === focusId)
+    const gradeForLane = focus ? focus.data.grade : currentChild?.grade
+    const bandNodes = gradeForLane
+      ? skillNodes.filter((n) => n.data.grade === gradeForLane)
+      : skillNodes
+    if (!bandNodes.length) return
+
+    centeredRef.current = true
+    const ids = bandNodes.map((n) => ({ id: n.id }))
+    if (gradeForLane) ids.push({ id: `lane-${gradeForLane}` })
+    setTimeout(() => {
+      fitView({
+        nodes: ids,
+        maxZoom: 1.3,
+        minZoom: minZoomRef.current,
+        padding: 0.02,
+        duration: 600
+      })
+    }, 50)
+  }, [rfReady, initialNodes, focusId, currentChild, fitView])
+
+  const applyFilter = useCallback(
+    (q, grade) => {
       const needle = q.trim().toLowerCase()
       const matchesQuery = (s) =>
         !needle ||
@@ -95,76 +187,53 @@ export default function SkillTreeScreen() {
           if (n.type !== "skillNode") return n
           const s = n.data
           let dim = false
-          if (related) dim = s.id !== focusId && !related.ancestors.has(s.id)
-          if (grade) dim = dim || s.grade !== grade
+          if (grade) dim = s.grade !== grade
           if (needle) dim = dim || !matchesQuery(s)
           return { ...n, style: { ...n.style, opacity: dim ? 0.2 : 1 } }
         })
       )
-      setEdges((es) =>
-        es.map((e) => {
-          let active = true
-          if (related) {
-            active =
-              (related.ancestors.has(e.source) || e.source === focusId) &&
-              (related.ancestors.has(e.target) || e.target === focusId)
-          }
-          const color = active && related ? "#3F6F4A" : "#A1AEA3"
-          return {
-            ...e,
-            style: {
-              ...e.style,
-              stroke: color,
-              strokeWidth: active && related ? 2 : 1.5,
-              strokeDasharray: active && related ? "0" : "4 5",
-              opacity: active ? 1 : 0.2,
-            },
-            markerEnd: { type: MarkerType.ArrowClosed, color, width: 12, height: 12 },
-          }
-        })
-      )
     },
-    [skills, successors, setNodes, setEdges]
+    [setNodes]
   )
 
-  const onNodeClick = useCallback(
-    (_, node) => {
-      if (node.type !== "skillNode") return
-      setSelected(node.data)
-      applyHighlight(node.id, query, gradeFilter)
-    },
-    [applyHighlight, query, gradeFilter]
-  )
+  const onNodeClick = useCallback((_, node) => {
+    if (node.type !== "skillNode") return
+    setSelected(node.data)
+  }, [])
 
   const onPaneClick = useCallback(() => {
     setSelected(null)
-    applyHighlight(null, query, gradeFilter)
-  }, [applyHighlight, query, gradeFilter])
+  }, [])
 
   const onQueryChange = useCallback(
     (e) => {
       const v = e.target.value
       setQuery(v)
-      applyHighlight(selected?.id ?? null, v, gradeFilter)
+      applyFilter(v, gradeFilter)
     },
-    [applyHighlight, selected, gradeFilter]
+    [applyFilter, gradeFilter]
   )
 
   const selectGrade = useCallback(
     (g) => {
       const next = gradeFilter === g ? null : g
       setGradeFilter(next)
-      applyHighlight(selected?.id ?? null, query, next)
+      applyFilter(query, next)
     },
-    [applyHighlight, gradeFilter, query, selected]
+    [applyFilter, gradeFilter, query]
   )
+
+  const onOverview = useCallback(() => {
+    fitView({ padding: 0.05, duration: 500 })
+    setSelected(null)
+  }, [fitView])
 
   const minimapColor = useCallback(
     (node) => node.data?.colors?.minimap ?? "#A1AEA3",
     []
   )
 
-  if (!skills) {
+  if (isLoading) {
     return (
       <div className="h-screen w-screen flex items-center justify-center bg-chalk text-stem">
         <span className="latin">Germinatio…</span>
@@ -174,37 +243,70 @@ export default function SkillTreeScreen() {
 
   return (
     <div className="h-screen w-screen flex flex-col bg-chalk">
-      <header className="flex items-center gap-4 px-6 py-3 border-b border-sage/10 bg-paper">
-        <a href="/" className="text-sage-deep hover:underline text-sm font-semibold">
+      <header className="flex items-center gap-3 px-4 md:px-6 py-3 border-b border-sage/10 bg-paper">
+        <a href="/" className="text-sage-deep hover:underline text-sm font-semibold shrink-0">
           ← Serre
         </a>
-        <div className="hidden md:block">
+        <div className="hidden md:block shrink-0">
           <LatinLabel>Hortus mathematicus</LatinLabel>
           <h1 className="font-display font-semibold text-lg text-bark leading-tight">
-            Carte des compétences
+            Carte des espèces
           </h1>
         </div>
-        <div className="flex items-center gap-1 ml-4">
+        <div className="flex items-center gap-1 ml-2 overflow-x-auto">
           {GRADES.map((g) => (
             <button
               key={g}
               onClick={() => selectGrade(g)}
-              className={`navlink ${gradeFilter === g ? "active" : ""}`}
+              className={`navlink shrink-0 ${gradeFilter === g ? "active" : ""}`}
             >
               {g}
             </button>
           ))}
         </div>
-        <Input
-          type="search"
-          value={query}
-          onChange={onQueryChange}
-          placeholder="Rechercher une plante…"
-          className="ml-auto !w-64"
-        />
+        <div className="ml-auto flex items-center gap-2">
+          <button
+            onClick={onOverview}
+            className="pill pill-ghost !py-2 !px-3 !text-xs"
+            aria-label="Vue d'ensemble"
+          >
+            Vue d'ensemble
+          </button>
+          <div className="hidden md:block">
+            <Input
+              type="search"
+              value={query}
+              onChange={onQueryChange}
+              placeholder="Rechercher une plante…"
+              className="!w-64"
+            />
+          </div>
+          <button
+            onClick={() => setSearchOpen((v) => !v)}
+            className="md:hidden navlink !p-2"
+            aria-label="Rechercher"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" />
+            </svg>
+          </button>
+        </div>
       </header>
 
-      <div className="flex-1 relative">
+      {searchOpen && (
+        <div className="md:hidden px-4 py-2 border-b border-sage/10 bg-paper">
+          <Input
+            type="search"
+            value={query}
+            onChange={onQueryChange}
+            placeholder="Rechercher une plante…"
+            autoFocus
+          />
+        </div>
+      )}
+
+      <div ref={flowRef} className="flex-1 relative">
+        <SkillTreeHoverContext.Provider value={hoverContext}>
         <ReactFlow
           nodes={nodes}
           edges={edges}
@@ -212,30 +314,35 @@ export default function SkillTreeScreen() {
           onEdgesChange={onEdgesChange}
           onNodeClick={onNodeClick}
           onPaneClick={onPaneClick}
+          onInit={onInit}
           nodeTypes={nodeTypes}
-          fitView
-          fitViewOptions={{ padding: 0.2 }}
-          minZoom={0.15}
-          maxZoom={2}
+          minZoom={minZoom}
+          maxZoom={1.5}
+          translateExtent={translateExtent}
           panOnScroll
           zoomOnScroll={false}
           zoomOnPinch
+          panOnDrag
           proOptions={{ hideAttribution: true }}
         >
           <Background color="rgba(63, 111, 74, 0.18)" gap={22} size={1} />
           <Controls position="bottom-right" showInteractive={false} />
-          <MiniMap
-            nodeColor={minimapColor}
-            maskColor="rgba(246, 248, 243, 0.7)"
-            position="bottom-left"
-            pannable
-            zoomable
-          />
+          <div className="hidden md:block">
+            <MiniMap
+              nodeColor={minimapColor}
+              maskColor="rgba(246, 248, 243, 0.7)"
+              position="bottom-left"
+              pannable
+              zoomable
+            />
+          </div>
         </ReactFlow>
+        </SkillTreeHoverContext.Provider>
 
         {selected && (
           <DetailPanel
             skill={selected}
+            state={stateById.get(selected.id)}
             onClose={onPaneClick}
             onPractice={(id) =>
               navigate(`/exercise?skill=${encodeURIComponent(id)}`)
@@ -248,15 +355,41 @@ export default function SkillTreeScreen() {
   )
 }
 
+export default function SkillTreeScreen() {
+  const selectedChildId = useAuthStore((s) => s.selectedChildId)
+
+  const { data: skills } = useQuery({
+    queryKey: ["skills"],
+    queryFn: async () => {
+      const data = await api.get("/skills/")
+      return data.map((s) => ({ ...s, prerequisites: s.prerequisite_ids }))
+    }
+  })
+
+  const { data: skillTreeData, isLoading: treeLoading } = useSkillTree(selectedChildId)
+
+  const isLoading = !skills || (selectedChildId && treeLoading)
+
+  return (
+    <ReactFlowProvider>
+      <SkillTreeInner
+        skills={skills}
+        skillTreeData={skillTreeData}
+        isLoading={isLoading}
+      />
+    </ReactFlowProvider>
+  )
+}
+
 function StatusLegend() {
   const items = [
     { label: "Floraison", color: "#E8C66A" },
-    { label: "En croissance", color: "#3F6F4A" },
+    { label: "En croissance", color: "#6FA274" },
     { label: "À arroser", color: "#4F8BAC" },
     { label: "En sommeil", color: "#A1AEA3" },
   ]
   return (
-    <Card className="absolute bottom-4 right-20 flex flex-col gap-1.5 px-3 py-2.5">
+    <Card className="hidden md:flex absolute bottom-4 right-20 flex-col gap-1.5 px-3 py-2.5">
       {items.map(({ label, color }) => (
         <div key={label} className="flex items-center gap-2 text-[11px] text-bark">
           <span className="w-2.5 h-2.5 rounded-full" style={{ background: color }} />
@@ -267,11 +400,13 @@ function StatusLegend() {
   )
 }
 
-function DetailPanel({ skill, onClose, onPractice }) {
+function DetailPanel({ skill, state, onClose, onPractice }) {
+  const pct = state ? Math.round(state.mastery_level * 100) : 0
+  const attempts = state?.total_attempts ?? 0
   return (
     <Card
       variant="tag"
-      className="absolute top-4 right-4 w-80 p-5 z-50 bg-paper"
+      className="absolute top-4 left-4 right-4 md:left-auto md:right-4 md:w-80 p-5 z-50 bg-paper"
     >
       <div className="flex items-start justify-between mb-3">
         <span className="chip chip-sky">
@@ -289,24 +424,26 @@ function DetailPanel({ skill, onClose, onPractice }) {
       <h3 className="font-display font-semibold text-bark text-base mt-0.5 leading-tight">
         {skill.label}
       </h3>
-      <p className="text-xs text-stem leading-relaxed mt-2">{skill.description}</p>
+      {attempts > 0 && (
+        <div className="mt-3">
+          <div className="flex items-baseline justify-between">
+            <span className="latin text-[11px]">Maîtrise</span>
+            <span className="font-mono text-sm font-semibold text-sage-deep">{pct}%</span>
+          </div>
+          <div className="mt-1 h-1.5 rounded-full bg-mist overflow-hidden">
+            <div className="h-full bg-sage transition-all duration-500" style={{ width: `${pct}%` }} />
+          </div>
+          <div className="text-[11px] text-stem mt-1">
+            {attempts} question{attempts > 1 ? "s" : ""} vues
+          </div>
+        </div>
+      )}
+      <p className="text-xs text-stem leading-relaxed mt-3">{skill.description}</p>
       <div className="flex items-center gap-4 text-xs text-stem mt-3">
         <span>Seuil · {skill.mastery_threshold}</span>
         <span>Racines · {skill.prerequisites.length}</span>
       </div>
-      {skill.prerequisites.length > 0 && (
-        <div className="mt-2 flex flex-wrap gap-1">
-          {skill.prerequisites.map((id) => (
-            <code
-              key={id}
-              className="text-[10px] bg-mist px-1.5 py-0.5 rounded text-stem font-mono"
-            >
-              {id}
-            </code>
-          ))}
-        </div>
-      )}
-      {onPractice && (
+      {onPractice && skill.unlocked && (
         <Button
           data-testid="practice-skill"
           onClick={() => onPractice(skill.id)}
@@ -315,6 +452,11 @@ function DetailPanel({ skill, onClose, onPractice }) {
         >
           Arroser cette plante
         </Button>
+      )}
+      {onPractice && !skill.unlocked && (
+        <p className="mt-3 text-xs text-stem italic">
+          Maîtrise d'abord les racines de cette plante.
+        </p>
       )}
     </Card>
   )

--- a/frontend/src/components/ui/SkillNode.jsx
+++ b/frontend/src/components/ui/SkillNode.jsx
@@ -1,8 +1,11 @@
+import { useContext } from "react"
 import { Handle, Position } from "@xyflow/react"
+import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
 
 const PLANT_STATE = {
   completed: "floraison",
   in_progress: "croissance",
+  review: "arroser",
   locked: "sommeil",
 }
 
@@ -11,6 +14,13 @@ const STATE_LABEL = {
   croissance: "En croissance",
   arroser: "À arroser",
   sommeil: "En sommeil",
+}
+
+const STATE_LATIN = {
+  floraison: "en fleurs",
+  croissance: "en croissance",
+  arroser: "à revoir",
+  sommeil: "en sommeil",
 }
 
 const PLANT_SVG = {
@@ -44,41 +54,106 @@ const PLANT_SVG = {
   ),
 }
 
-export default function SkillNode({ data }) {
-  const { label, colors, status, isNext, family } = data
+export default function SkillNode({ id, data }) {
+  const { hoveredId, prereqs } = useContext(SkillTreeHoverContext)
+  const isPrereqOfHover = prereqs.has(id)
+  const isHoverTarget = hoveredId === id
+  const {
+    label, status, isNext, family,
+    masteryLevel = 0, totalAttempts = 0, unlocked = true,
+  } = data
   const baseState = PLANT_STATE[status] ?? "sommeil"
-  const state = isNext ? "arroser" : baseState
+  const state = isNext && status !== "completed" ? "arroser" : baseState
+  const pct = Math.round(masteryLevel * 100)
+  const isLocked = !unlocked
+  const isBloom = state === "floraison"
+  const isCroissance = state === "croissance"
 
-  const ringClass = state === "arroser" ? "border-sky-deep" : "border-transparent"
-  const opacity = state === "sommeil" ? 0.75 : 1
+  const cardStyle = {}
+  if (state === "floraison") {
+    cardStyle.background = "#3F6F4A"
+    cardStyle.borderColor = "transparent"
+  } else if (isCroissance) {
+    cardStyle.borderColor = "#6FA274"
+    cardStyle.borderWidth = 2
+  } else if (state === "arroser") {
+    cardStyle.borderColor = "#4F8BAC"
+    cardStyle.borderWidth = 2
+  }
+
+  const dim = state === "sommeil" && totalAttempts === 0
+  const barFill = state === "arroser" ? "#4F8BAC" : "#6FA274"
 
   return (
-    <div className="relative flex flex-col items-center" style={{ width: 140, opacity }}>
-      {isNext && (
+    <div
+      className="group relative flex flex-col items-center"
+      style={{ width: 140, opacity: dim && !isPrereqOfHover && !isHoverTarget ? 0.75 : 1 }}
+    >
+      {isNext && state !== "floraison" && (
         <div className="absolute -top-7 chip chip-sky whitespace-nowrap z-10 !text-[10px]">
           À arroser aujourd'hui
         </div>
       )}
+      {isCroissance && !isNext && (
+        <div className="absolute -top-7 chip whitespace-nowrap z-10 !text-[10px] bg-sage-leaf text-sage-deep border border-sage/30">
+          <span className="inline-block w-1.5 h-1.5 rounded-full bg-sage-deep" />
+          Tu travailles ici
+        </div>
+      )}
+      {isLocked && !isNext && !isCroissance && (
+        <div
+          className="absolute -top-7 chip whitespace-nowrap z-10 !text-[10px] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
+          role="tooltip"
+        >
+          Pas encore accessible
+        </div>
+      )}
+      {isPrereqOfHover && (
+        <div className="absolute inset-0 rounded-[0.875rem] pointer-events-none prereq-glow z-0" />
+      )}
       <div
-        className={`specimen ${ringClass} cursor-pointer transition-transform hover:-translate-y-0.5 w-full px-3 pt-3 pb-2`}
-        style={{
-          borderWidth: state === "arroser" ? 2 : 1,
-        }}
+        className={`specimen relative w-full px-3 pt-3 pb-2.5 transition-transform duration-200 origin-center group-hover:scale-[1.06] group-hover:z-10 ${isCroissance ? "specimen-croissance" : ""} ${isLocked ? "cursor-help" : "cursor-pointer"}`}
+        style={cardStyle}
       >
         <div
-          className="rounded-md h-14 flex items-center justify-center"
-          style={{ backgroundColor: `${colors.bg}90` }}
+          className="rounded-md h-11 flex items-center justify-center"
+          style={{ backgroundColor: isBloom ? "rgba(255,255,255,0.1)" : "rgba(198,224,181,0.35)" }}
         >
-          <svg viewBox="0 0 32 32" className="w-9 h-9">
+          <svg viewBox="0 0 32 32" className="w-7 h-7">
             {PLANT_SVG[state]}
           </svg>
         </div>
         <div className="mt-2 text-center">
-          <div className="text-[11px] font-semibold leading-tight text-bark">{label}</div>
-          <div className="latin text-[9px] leading-tight mt-0.5">{family}</div>
+          <div
+            className="text-[11px] font-semibold leading-tight"
+            style={{ color: isBloom ? "#ffffff" : "#2B3A2E" }}
+          >
+            {label}
+          </div>
+          <div
+            className="latin text-[9px] leading-tight mt-0.5"
+            style={{ color: isBloom ? "rgba(255,255,255,0.75)" : undefined }}
+          >
+            {family} · {totalAttempts > 0 ? `${pct}%` : STATE_LATIN[state]}
+          </div>
+        </div>
+        <div
+          className="mt-2 h-1 rounded-full overflow-hidden"
+          style={{ background: isBloom ? "rgba(255,255,255,0.25)" : "#ECF1E7" }}
+        >
+          <div
+            className="h-full transition-all duration-500"
+            style={{
+              width: `${Math.max(isBloom ? 100 : pct, 0)}%`,
+              background: isBloom ? "#E8C66A" : barFill
+            }}
+          />
         </div>
       </div>
-      <div className="mt-1 text-[9px] font-semibold uppercase tracking-wider" style={{ color: colors.text }}>
+      <div
+        className="mt-1 text-[9px] font-semibold uppercase tracking-wider"
+        style={{ color: state === "arroser" ? "#4F8BAC" : state === "floraison" ? "#8A6A1F" : "#5C6B5F" }}
+      >
         {STATE_LABEL[state]}
       </div>
       <Handle type="target" position={Position.Top} className="!opacity-0 !bg-transparent" />

--- a/frontend/src/hooks/useSkillTree.js
+++ b/frontend/src/hooks/useSkillTree.js
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query"
+import { studentsApi } from "../api/students"
+import { skillTreeKey } from "../lib/queryClient"
+
+export function useSkillTree(studentId) {
+  return useQuery({
+    queryKey: skillTreeKey(studentId),
+    queryFn: () => studentsApi.skillTree(studentId),
+    enabled: Boolean(studentId)
+  })
+}

--- a/frontend/src/lib/queryClient.js
+++ b/frontend/src/lib/queryClient.js
@@ -1,0 +1,14 @@
+import { QueryClient } from "@tanstack/react-query"
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: { staleTime: 30_000, refetchOnWindowFocus: false }
+  }
+})
+
+export const skillTreeKey = (studentId) => ["skillTree", studentId]
+
+export const invalidateSkillTree = (studentId) => {
+  if (!studentId) return
+  queryClient.invalidateQueries({ queryKey: skillTreeKey(studentId) })
+}

--- a/frontend/src/lib/skillTreeHoverContext.js
+++ b/frontend/src/lib/skillTreeHoverContext.js
@@ -1,0 +1,6 @@
+import { createContext } from "react"
+
+export const SkillTreeHoverContext = createContext({
+  hoveredId: null,
+  prereqs: new Set()
+})

--- a/frontend/src/lib/skillTreeLayout.js
+++ b/frontend/src/lib/skillTreeLayout.js
@@ -30,16 +30,23 @@ function familyFor(id) {
   return "scientia"
 }
 
-function mockStatus(skill) {
-  if (skill.grade === "P1") return "completed"
-  if (skill.grade === "P2") return "in_progress"
-  return "locked"
+const BACKEND_TO_UI_STATUS = {
+  mastered: "completed",
+  in_progress: "in_progress",
+  needs_review: "review",
+  not_started: "locked"
+}
+
+function skillStatus(skill, stateById) {
+  const state = stateById?.get(skill.id)
+  if (!state) return "locked"
+  return BACKEND_TO_UI_STATUS[state.status] ?? "locked"
 }
 
 export const NODE_WIDTH = 140
 export const NODE_GAP_X = 24
 export const SUBROW_HEIGHT = 170
-export const BAND_GAP = 60
+export const BAND_GAP = 110
 export const BAND_PAD_TOP = 40
 const LANE_LABEL_X = -180
 
@@ -82,7 +89,7 @@ function orderByBarycenter(skills, positions, successors, useSuccessors) {
   return withBary.map(({ s }) => s)
 }
 
-export function buildGraph(skills, nextId) {
+export function buildGraph(skills, nextId, stateById) {
   const byGrade = new Map(GRADES.map((g) => [g, []]))
   for (const s of skills) {
     if (byGrade.has(s.grade)) byGrade.get(s.grade).push(s)
@@ -129,12 +136,26 @@ export function buildGraph(skills, nextId) {
     yAcc += BAND_GAP
   }
 
+  let maxRowSize = 1
+  for (const grade of GRADES) {
+    const info = gradeInfo.get(grade)
+    for (let r = 0; r < info.rowCount; r++) {
+      const sz = (info.rows.get(r) ?? []).length
+      if (sz > maxRowSize) maxRowSize = sz
+    }
+  }
+  const stride = NODE_WIDTH + NODE_GAP_X
+  const rowCenter = (maxRowSize * stride - NODE_GAP_X) / 2
+
   const positions = new Map()
   const placeRow = (rowSkills, grade, r, useSucc) => {
     const ordered = orderByBarycenter(rowSkills, positions, successors, useSucc)
+    if (!ordered.length) return
+    const rowWidth = ordered.length * stride - NODE_GAP_X
+    const startX = rowCenter - rowWidth / 2
     ordered.forEach((s, i) => {
       positions.set(s.id, {
-        x: i * (NODE_WIDTH + NODE_GAP_X),
+        x: startX + i * stride,
         y: gradeYStart.get(grade) + r * SUBROW_HEIGHT,
       })
     })
@@ -164,29 +185,52 @@ export function buildGraph(skills, nextId) {
   const allX = [...positions.values()].map((p) => p.x)
   const maxX = allX.length ? Math.max(...allX) : 0
 
-  const nodes = skills.map((s) => ({
-    id: s.id,
-    type: "skillNode",
-    position: positions.get(s.id),
-    data: {
-      ...s,
-      colors: GRADE_COLORS[s.grade],
-      family: familyFor(s.id),
-      status: mockStatus(s),
-      isNext: s.id === nextId,
-    },
-    draggable: false,
-  }))
+  const isMastered = (id) => stateById?.get(id)?.status === "mastered"
+  const hasAttempts = (id) => (stateById?.get(id)?.total_attempts ?? 0) > 0
+  const isUnlocked = (s) =>
+    hasAttempts(s.id) ||
+    s.prerequisites.length === 0 ||
+    s.prerequisites.every(isMastered)
+
+  const nodes = skills.map((s) => {
+    const state = stateById?.get(s.id)
+    return {
+      id: s.id,
+      type: "skillNode",
+      position: positions.get(s.id),
+      data: {
+        ...s,
+        colors: GRADE_COLORS[s.grade],
+        family: familyFor(s.id),
+        status: skillStatus(s, stateById),
+        masteryLevel: state?.mastery_level ?? 0,
+        totalAttempts: state?.total_attempts ?? 0,
+        unlocked: isUnlocked(s),
+        isNext: s.id === nextId,
+      },
+      draggable: false,
+    }
+  })
 
   const edges = skills.flatMap((s) =>
-    s.prerequisites.map((pid) => ({
-      id: `${pid}->${s.id}`,
-      source: pid,
-      target: s.id,
-      type: "smoothstep",
-      style: { stroke: "#A1AEA3", strokeWidth: 1.5, strokeDasharray: "4 5" },
-      markerEnd: { type: MarkerType.ArrowClosed, color: "#A1AEA3", width: 12, height: 12 },
-    }))
+    s.prerequisites.map((pid) => {
+      const lit = isMastered(pid) && isMastered(s.id)
+      const active = isMastered(pid) && !isMastered(s.id) &&
+        (stateById?.get(s.id)?.status === "in_progress" || s.id === nextId)
+      let stroke = "#A1AEA3"
+      let width = 1.5
+      let dash = "4 5"
+      if (lit) { stroke = "#6FA274"; width = 2.5; dash = "0" }
+      else if (active) { stroke = "#4F8BAC"; width = 2; dash = "0" }
+      return {
+        id: `${pid}->${s.id}`,
+        source: pid,
+        target: s.id,
+        type: "smoothstep",
+        style: { stroke, strokeWidth: width, strokeDasharray: dash },
+        markerEnd: { type: MarkerType.ArrowClosed, color: stroke, width: 12, height: 12 },
+      }
+    })
   )
 
   const laneNodes = GRADES.map((grade) => {
@@ -204,35 +248,17 @@ export function buildGraph(skills, nextId) {
       },
       draggable: false,
       selectable: false,
+      style: { pointerEvents: "none" },
     }
   })
 
-  return { nodes: [...laneNodes, ...nodes], edges, successors }
-}
+  const lastGrade = GRADES[GRADES.length - 1]
+  const bounds = {
+    minX: LANE_LABEL_X,
+    maxX: maxX + NODE_WIDTH + 40,
+    minY: 0,
+    maxY: gradeYEnd.get(lastGrade) + 40,
+  }
 
-export function collectRelated(id, skills, successors) {
-  const byId = new Map(skills.map((s) => [s.id, s]))
-  const ancestors = new Set()
-  const stackA = [id]
-  while (stackA.length) {
-    const cur = stackA.pop()
-    for (const p of byId.get(cur)?.prerequisites ?? []) {
-      if (!ancestors.has(p)) {
-        ancestors.add(p)
-        stackA.push(p)
-      }
-    }
-  }
-  const descendants = new Set()
-  const stackD = [id]
-  while (stackD.length) {
-    const cur = stackD.pop()
-    for (const c of successors.get(cur) ?? []) {
-      if (!descendants.has(c)) {
-        descendants.add(c)
-        stackD.push(c)
-      }
-    }
-  }
-  return { ancestors, descendants }
+  return { nodes: [...laneNodes, ...nodes], edges, bounds }
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,7 +1,8 @@
 import { StrictMode } from "react"
 import { createRoot } from "react-dom/client"
 import { BrowserRouter } from "react-router"
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { QueryClientProvider } from "@tanstack/react-query"
+import { queryClient } from "./lib/queryClient"
 import "@fontsource/fraunces/400.css"
 import "@fontsource/fraunces/500.css"
 import "@fontsource/fraunces/600.css"
@@ -13,8 +14,6 @@ import "@fontsource/inter/700.css"
 import "@fontsource/jetbrains-mono/500.css"
 import "./index.css"
 import App from "./App.jsx"
-
-const queryClient = new QueryClient()
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>

--- a/frontend/src/stores/diagnosticStore.js
+++ b/frontend/src/stores/diagnosticStore.js
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 import { diagnosticApi } from "../api/diagnostic"
+import { invalidateSkillTree } from "../lib/queryClient"
 import { useAuthStore } from "./authStore"
 import { useBadgeStore } from "./badgeStore"
 
@@ -50,6 +51,7 @@ export const useDiagnosticStore = create((set, get) => ({
         useAuthStore.getState().applyGamification(studentId, res.gamification)
         useBadgeStore.getState().push(res.gamification.newly_earned_badges)
       }
+      invalidateSkillTree(studentId)
       set({ feedback: res.feedback, loading: false })
     } catch (err) {
       set({ error: err.message, loading: false })

--- a/frontend/src/stores/drillStore.js
+++ b/frontend/src/stores/drillStore.js
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 import { drillApi } from "../api/drill"
+import { invalidateSkillTree } from "../lib/queryClient"
 import { useAuthStore } from "./authStore"
 import { useBadgeStore } from "./badgeStore"
 
@@ -56,6 +57,7 @@ export const useDrillStore = create((set, get) => ({
         useAuthStore.getState().applyGamification(studentId, res.gamification)
         useBadgeStore.getState().push(res.gamification.newly_earned_badges)
       }
+      invalidateSkillTree(studentId)
       set({
         feedback: res.feedback,
         streak: nextStreak,

--- a/frontend/src/stores/sessionStore.js
+++ b/frontend/src/stores/sessionStore.js
@@ -1,5 +1,6 @@
 import { create } from "zustand"
 import { exercisesApi } from "../api/exercises"
+import { invalidateSkillTree } from "../lib/queryClient"
 import { useAuthStore } from "./authStore"
 import { useBadgeStore } from "./badgeStore"
 
@@ -60,6 +61,7 @@ export const useSessionStore = create((set, get) => ({
         useAuthStore.getState().applyGamification(studentId, res.gamification)
         useBadgeStore.getState().push(res.gamification.newly_earned_badges)
       }
+      invalidateSkillTree(studentId)
       set({
         feedback: res.feedback,
         lastAttemptId: res.attempt?.id || null,


### PR DESCRIPTION
## Summary
- Wire skill tree to real `StudentSkillState` data via `/students/{id}/skill-tree/` endpoint + TanStack Query
- Center each row horizontally (pyramid shape), add colored grade bands with accent stripes, increase band gap for clear year separation
- Dynamic `minZoom` via ResizeObserver so tree fills viewport width; `translateExtent` prevents panning into void
- Seed prior-grade mastery on student creation (P3 student gets all P1+P2 mastered)
- Playwright e2e spec for skill tree rendering with seeded mastery states

Known issue: node clickability is blocked by lane label pointer events — tracked in #80.

## Test plan
- [ ] Register a P3 student → skill tree shows P1/P2 as FLORAISON, P3 as EN SOMMEIL
- [ ] Tree layout is centered (narrow rows centered, wide rows fill width)
- [ ] Grade bands (P1–P6) are visually distinct with colored backgrounds
- [ ] Zooming out stops at the viewport-filling zoom level
- [ ] Panning is bounded — can't scroll into empty space
- [ ] `npx playwright test skilltree-preview` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)