### PR TITLE
fix(#22): self-contained compose via env_file + localhost for healthcheck

### DIFF
--- a/prod/.env.prod.example
+++ b/prod/.env.prod.example
@@ -5,18 +5,16 @@
 DOMAIN=collegia.be
 CADDY_EMAIL=you@example.com
 
-# ===== Images =====
-BACKEND_IMAGE=ghcr.io/yassinebenyaghlane/pedagogia-backend:latest
-FRONTEND_IMAGE=ghcr.io/yassinebenyaghlane/pedagogia-frontend:latest
-
 # ===== Database (internal, never exposed on host) =====
 POSTGRES_DB=pedagogia
 POSTGRES_USER=pedagogia
 POSTGRES_PASSWORD=__generate_with__openssl_rand_-base64_32__
+DATABASE_URL=postgres://pedagogia:__same_as_POSTGRES_PASSWORD__@db:5432/pedagogia
 
 # ===== Django =====
 DJANGO_SECRET_KEY=__generate_with__python_-c_"import secrets; print(secrets.token_urlsafe(64))"__
-DJANGO_ALLOWED_HOSTS=collegia.be,www.collegia.be
+# localhost is required for the backend container's in-container healthcheck.
+DJANGO_ALLOWED_HOSTS=collegia.be,www.collegia.be,localhost
 CORS_ORIGINS=https://collegia.be,https://www.collegia.be
 CSRF_TRUSTED_ORIGINS=https://collegia.be,https://www.collegia.be
 GUNICORN_WORKERS=3

--- a/prod/docker-compose.prod.yml
+++ b/prod/docker-compose.prod.yml
@@ -2,14 +2,12 @@ services:
   db:
     image: postgres:16-alpine
     restart: unless-stopped
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    env_file:
+      - .env.prod
     volumes:
       - pgdata:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 10s
       timeout: 5s
       retries: 10
@@ -22,14 +20,13 @@ services:
         max-file: "3"
 
   backend:
-    image: ${BACKEND_IMAGE:-ghcr.io/yassinebenyaghlane/pedagogia-backend:latest}
+    image: ghcr.io/yassinebenyaghlane/pedagogia-backend:latest
     restart: unless-stopped
     pull_policy: always
     env_file:
       - .env.prod
     environment:
       DJANGO_SETTINGS_MODULE: pedagogia.settings.prod
-      DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
       DJANGO_DEV_SERVER: "0"
     depends_on:
       db:
@@ -51,16 +48,15 @@ services:
         max-file: "5"
 
   frontend:
-    image: ${FRONTEND_IMAGE:-ghcr.io/yassinebenyaghlane/pedagogia-frontend:latest}
+    image: ghcr.io/yassinebenyaghlane/pedagogia-frontend:latest
     restart: unless-stopped
     pull_policy: always
     ports:
       - "80:80"
       - "443:443"
       - "443:443/udp"
-    environment:
-      DOMAIN: ${DOMAIN}
-      CADDY_EMAIL: ${CADDY_EMAIL}
+    env_file:
+      - .env.prod
     volumes:
       - caddy_data:/data
       - caddy_config:/config


### PR DESCRIPTION
Follow-up to #85. Found while bringing up `https://collegia.be` for the first time.

## What broke and why
1. `docker-compose.prod.yml` used compose-level `${POSTGRES_*}`, `${DOMAIN}`, `${CADDY_EMAIL}` interpolation, which only reads `.env` (not `.env.prod`) unless you pass `--env-file .env.prod`. Operators would need to remember the flag on every `pull` / `up` / `restart`.
2. The backend container's healthcheck hits `http://localhost:8000/api/health/`. Django rejected it because `ALLOWED_HOSTS` didn't include `localhost`, failing the check loop and blocking `depends_on: service_healthy` for Caddy.

## Fix
- Per-service `env_file: .env.prod` on every service; hardcoded image URLs (GHCR path is deterministic). No more `--env-file` flag anywhere.
- `DATABASE_URL` moved into `.env.prod.example` (no longer built via interpolation).
- `localhost` added to `DJANGO_ALLOWED_HOSTS` example, with a comment explaining why.

## Verification
Manually applied to the server, then `docker compose up -d --force-recreate` → db healthy, backend healthy, Caddy got valid Let's Encrypt certs for `collegia.be` + `www.collegia.be`, `https://collegia.be/api/health/` returns `{"status":"ok"}`, HSTS/X-Frame/nosniff all present, HTTP→HTTPS 308.

## Test plan
- [ ] CI green
- [ ] Merge triggers deploy workflow
- [ ] Server keeps serving (no-op for already-running stack; compose diff is detected → backend + frontend recreated cleanly)