### PR TITLE
docs(#22): architecture reference, CLAUDE.md prod pointer, wiki + prod-ops skill

### DIFF
--- a/.claude/skills/prod-ops/SKILL.md
+++ b/.claude/skills/prod-ops/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: prod-ops
+description: Operate the collegia.be production stack — SSH into the server, tail prod logs, redeploy, restart a service, edit .env.prod, investigate a prod incident, roll back a bad deploy, or bootstrap a new VPS. Use this skill whenever the user mentions "prod", "production", "collegia.be", "the server", "deploy / redeploy / rollback", "prod logs", "check the stack", "the VPS", "Hetzner", "Caddy", "GHCR", or any variant in French ("la prod", "le serveur", "les logs", "redéployer"). Also worth using proactively when a GitHub Actions deploy run is failing, when a user-facing bug that might be prod-specific is reported, or before landing an infra PR. This is NOT the skill for the dev stack — that's `run-app`. The reason this skill exists: prod is shared state with real users; the ops flow has a few non-obvious gotchas (env_file semantics, GHCR visibility, Caddy cert dance) that waste time if rediscovered every session.
+---
+
+# Prod ops — `collegia.be`
+
+Pointer skill, not a textbook. The full architecture lives in `docs/architecture.md` and the concept page `vault/wiki/concepts/prod-stack.md`. The first-time server setup is in `prod/bootstrap.md`. **Read those first** if you need to understand *why* something is the shape it is — this file covers *how to touch it* day-to-day.
+
+## The shape, in one paragraph
+
+One Hetzner cx23 at `46.225.142.212` (DNS `collegia.be`), Ubuntu 24.04. Three docker containers: `db` (internal postgres:16-alpine), `backend` (Django + Gunicorn, image `ghcr.io/yassinebenyaghlane/pedagogia-backend:latest`), `frontend` (Caddy + Vite build baked in, image `ghcr.io/yassinebenyaghlane/pedagogia-frontend:latest`, the only one with host ports 80/443). Compose file on the server: `/opt/pedagogia/docker-compose.prod.yml`. Secrets on the server: `/opt/pedagogia/.env.prod` (chmod 600, never in git). Everything else — source code, Caddyfile, Dockerfiles — lives in the repo only, baked into the images at build time. Deploys are fully automated: push to `main` → GH Actions builds both images → pushes to GHCR → SSHes in → `docker compose pull && up -d --remove-orphans`. You rarely need to touch the server by hand; when you do, SSH as `pedagogia` (uid 1000, non-root, docker group). Root login and password auth are disabled.
+
+## SSH
+
+```bash
+ssh pedagogia@46.225.142.212
+```
+
+Your laptop key is authorized. A second key (`~/.ssh/collegia_deploy`) is also authorized for CI — don't revoke it unless you're rotating.
+
+If you get `Permission denied (publickey)`: your key passphrase isn't in the agent. Run `ssh-add --apple-use-keychain ~/.ssh/id_ed25519` in a real terminal (not the Claude Code bash shell — it can't prompt for the passphrase).
+
+## Observe
+
+```bash
+# Stack status (replace with actual service names)
+ssh pedagogia@46.225.142.212 'docker compose -f /opt/pedagogia/docker-compose.prod.yml ps'
+
+# Live logs for one service (db / backend / frontend)
+ssh pedagogia@46.225.142.212 'docker logs pedagogia-backend-1 --tail=100 -f'
+
+# All services, last 50 lines, following
+ssh pedagogia@46.225.142.212 'docker compose -f /opt/pedagogia/docker-compose.prod.yml logs --tail=50 -f'
+
+# Public health probe (off the server)
+curl -fsSL https://collegia.be/api/health/
+
+# Last deploy runs
+gh run list --workflow=deploy.yml --limit 3
+```
+
+Container health is the fastest signal. If `docker compose ps` shows a service as `(unhealthy)`, go straight to its logs; don't guess.
+
+## Redeploy
+
+The normal path is **merge to `main`** — the pipeline handles the rest. Check the Deploy workflow on GitHub to confirm it succeeded.
+
+Manual redeploy (same image tag, server-side) — useful when `.env.prod` changed but the image didn't:
+
+```bash
+ssh pedagogia@46.225.142.212 'cd /opt/pedagogia && docker compose -f docker-compose.prod.yml pull && docker compose -f docker-compose.prod.yml up -d --remove-orphans'
+```
+
+Force-pull latest GHCR image even if tag looks unchanged:
+
+```bash
+ssh pedagogia@46.225.142.212 'cd /opt/pedagogia && docker compose -f docker-compose.prod.yml pull backend frontend && docker compose -f docker-compose.prod.yml up -d'
+```
+
+## Editing `.env.prod`
+
+The file lives **only on the server**, chmod 600, owned by `pedagogia`. Template (for reference) is `prod/.env.prod.example` in the repo.
+
+```bash
+ssh pedagogia@46.225.142.212
+cd /opt/pedagogia
+nano .env.prod        # or: vi .env.prod
+```
+
+**The non-obvious gotcha**: `docker compose restart <service>` does **NOT** re-read `env_file`. The container starts with its original env snapshot. To pick up new values you must recreate the container:
+
+```bash
+docker compose -f docker-compose.prod.yml up -d --force-recreate backend
+# or for multiple:
+docker compose -f docker-compose.prod.yml up -d --force-recreate backend frontend
+```
+
+If `--force-recreate` without arguments is needed, list the services explicitly — `up -d --force-recreate` alone on the whole stack will recreate `db` too, which is fine but wastes 10s of restart time.
+
+## Restarting a single service
+
+When you want the binary to restart but the env is unchanged:
+
+```bash
+ssh pedagogia@46.225.142.212 'docker compose -f /opt/pedagogia/docker-compose.prod.yml restart backend'
+```
+
+After a crash loop, `docker compose ps` will show restart counts. Grab the last 200 log lines before killing the container to preserve the diagnostic.
+
+## Rolling back a bad deploy
+
+CI tags every image with both `:latest` and `:sha-<commit>`. To pin the stack to a known-good commit:
+
+```bash
+ssh pedagogia@46.225.142.212
+cd /opt/pedagogia
+# 1. find the previous good SHA (gh run list on your laptop)
+# 2. edit the compose file temporarily OR add to .env.prod:
+#    BACKEND_IMAGE=ghcr.io/yassinebenyaghlane/pedagogia-backend:sha-<goodsha>
+#    FRONTEND_IMAGE=ghcr.io/yassinebenyaghlane/pedagogia-frontend:sha-<goodsha>
+# 3. pull + recreate:
+docker compose -f docker-compose.prod.yml pull
+docker compose -f docker-compose.prod.yml up -d --force-recreate backend frontend
+```
+
+The *real* fix is still "revert on `main` and let the pipeline redeploy". Rollback is a stopgap while you debug.
+
+## Bootstrapping a fresh VPS
+
+Don't improvise. The runbook is `prod/bootstrap.md` in the repo — it covers the Hetzner firewall, user creation, Docker install, SSH hardening, scp'ing the compose file, writing `.env.prod`, and first `up -d`. Follow it end-to-end.
+
+## Caddy / TLS
+
+Caddy manages Let's Encrypt certs automatically (tls-alpn-01 challenge). Certs live in the named volume `caddy_data` — **don't delete it** unless you want to re-issue and risk rate-limiting. If Caddy can't renew:
+
+```bash
+ssh pedagogia@46.225.142.212 'docker logs pedagogia-frontend-1 --tail=200 | grep -E "(error|ACME|challenge)"'
+```
+
+Common causes: DNS misconfigured (check `dig +short collegia.be` matches the server's IPv4/IPv6); port 80 blocked by the Hetzner firewall (it shouldn't be — check `hcloud firewall describe pedagogia-web`); `CADDY_EMAIL` missing from `.env.prod`.
+
+## Investigating a prod incident
+
+Mental checklist, in order:
+
+1. **Is it up?** — `curl -fsSL https://collegia.be/api/health/`. If this succeeds, Django + DB are fine; the problem is client-side or scoped.
+2. **What does the user see?** — get the exact URL and error. 502/504 → backend down. 400 `DisallowedHost` → `ALLOWED_HOSTS` misconfigured. 403 CSRF → `CSRF_TRUSTED_ORIGINS` or cookie issue. 500 → Django error, read backend logs.
+3. **Stack state** — `docker compose ps` on the server.
+4. **Recent deploy?** — `gh run list --workflow=deploy.yml --limit 5`. If a deploy landed just before the incident, correlate.
+5. **Logs** — `docker logs pedagogia-backend-1 --tail=200` for Django, `pedagogia-frontend-1` for Caddy, `pedagogia-db-1` for Postgres.
+
+## Things that require explicit user confirmation
+
+Production is shared state with real users. Never do any of these without an explicit ack in the current conversation:
+
+- `docker compose down -v` or removing the `pgdata` volume — this **destroys the database**.
+- `git push --force` / `--force-with-lease` to `main`.
+- Recreating the VPS, resizing it destructively, or running `hcloud server delete`.
+- Rotating `DJANGO_SECRET_KEY` (invalidates every active session).
+- Flipping GHCR package visibility to private (breaks the next deploy since the server pulls anonymously).
+- Anything destructive on the Hetzner firewall or DNS records.
+
+Destructive but reversible (image prune, log truncation, recreating a single non-db container) can proceed without extra confirmation.
+
+## Infra changes go through a PR, not SSH
+
+Tempting when you're in the server: `nano docker-compose.prod.yml`. Don't. The source of truth is `prod/docker-compose.prod.yml` in the repo — edit there, PR it, merge, then scp the new compose file up (the deploy workflow only handles image updates, not compose-file changes). Otherwise the next CI deploy or a server rebuild will silently revert your fix.
+
+Same for the Caddyfile: it's baked into the frontend image at build time. To change TLS or header config, edit `prod/Caddyfile` in the repo and ship through CI.
+
+## Cheat sheet
+
+| Intent | Command |
+|---|---|
+| Am I in? | `ssh pedagogia@46.225.142.212 'whoami && docker ps'` |
+| Stack status | `ssh pedagogia@46.225.142.212 'docker compose -f /opt/pedagogia/docker-compose.prod.yml ps'` |
+| Tail one service | `ssh pedagogia@46.225.142.212 'docker logs pedagogia-<svc>-1 --tail=100 -f'` |
+| Public health | `curl -fsSL https://collegia.be/api/health/` |
+| Last deploys | `gh run list --workflow=deploy.yml --limit 3` |
+| Pick up new env | `ssh pedagogia@46.225.142.212 'cd /opt/pedagogia && docker compose -f docker-compose.prod.yml up -d --force-recreate <svc>'` |
+| Manual redeploy | `ssh pedagogia@46.225.142.212 'cd /opt/pedagogia && docker compose -f docker-compose.prod.yml pull && docker compose -f docker-compose.prod.yml up -d --remove-orphans'` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,10 @@ npm run test:e2e:ui     # Playwright UI runner
 
 API docs: `/api/docs/` (drf-spectacular Swagger). Health: `/api/health/`.
 
+## Production
+
+Live at `https://collegia.be` (Hetzner cx23, `nbg1`). Two-image split (`pedagogia-backend` + `pedagogia-frontend`) built in CI and pushed to GHCR; server pulls `:latest` and restarts via SSH on every push to `main`. Caddy owns TLS + SPA + reverse proxy. Full map in [`docs/architecture.md`](docs/architecture.md); server bootstrap in [`prod/bootstrap.md`](prod/bootstrap.md).
+
 ## Architecture
 
 ### Backend — Django 5 + DRF + Claude API
@@ -158,4 +162,4 @@ Metaphor: a calm botanical greenhouse. Each skill is a plant, each session a car
 
 ## Open work (high-level)
 
-Open issues focus on UX/gamification (XP & ranks, badges, streaks, knowledge map, age-adaptive UI), data export & session history, PWA/offline support, and production deployment (VPS + HTTPS). Check `gh issue list` for the current state.
+Open issues focus on UX/gamification (XP & ranks, badges, streaks, knowledge map, age-adaptive UI), data export & session history, and PWA/offline support. Production is live; follow-ups tracked as infra issues. Check `gh issue list` for the current state.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,132 @@
+# Architecture
+
+High-level map of PedagogIA in dev and in prod. Updated 2026-04-17.
+
+## Product recap
+
+- French-language adaptive math for FWB students (P1–P6, Champ 3 arithmétique in the POC).
+- A **User** owns one or more **Student** profiles. The student picks their profile and learns via three modes: *diagnostic*, *drill* (targeted practice), *free practice* (spaced-repetition over the skill tree).
+- Wrong answers trigger an **AI investigation** (Claude API) that reasons over the skill tree + mastery state to pick the next probe.
+
+## Dev stack
+
+```
+┌──────────┐      ┌──────────┐      ┌──────────┐
+│ :5173    │      │ :8000    │      │ :5411    │
+│ frontend │─────▶│ backend  │─────▶│ db       │
+│ Vite dev │      │ Django   │      │ postgres │
+│          │ /api │ runserver│      │ 16-alpine│
+└──────────┘      └──────────┘      └──────────┘
+   bind-mount       bind-mount        pgdata vol
+   ./frontend       ./backend
+```
+
+- `docker-compose.yml` at repo root. `.env` at repo root.
+- Vite dev server proxies `/api` to `http://backend:8000` via `VITE_API_PROXY_TARGET`.
+- Source is bind-mounted for hot reload.
+- Backend entrypoint is `backend/start.sh` which runs `migrate` + `collectstatic` + `seed_skills` + `seed_templates` then branches on `DJANGO_DEV_SERVER` for `runserver` vs `gunicorn`.
+
+## Prod stack — `collegia.be`
+
+```
+Internet
+   │
+   ▼ 80/443 (only ports open on Hetzner firewall)
+┌────────────────────┐
+│ frontend container │  Caddy 2-alpine
+│ (Let's Encrypt TLS)│  - serves SPA from /srv
+│                    │  - try_files {path} /index.html  (SPA deep links)
+│                    │  - reverse_proxy /api/* /admin/* /static/* → backend:8000
+└─────────┬──────────┘
+          │ docker bridge (backend_net)
+   ┌──────┴───────┐
+   ▼              ▼
+┌──────────┐  ┌──────────┐
+│ backend  │  │   db     │
+│ Django + │  │ postgres │
+│ Gunicorn │  │ 16-alpine│
+│ uid 1000 │  │ internal │
+│ :8000    │  │ only     │
+└──────────┘  └──────────┘
+              pgdata vol (host)
+```
+
+### Host (Hetzner cx23, Ubuntu 24.04, `nbg1`)
+
+- One VPS: `46.225.142.212` / `2a01:4f8:c0c:1dbf::1`, €3.99/mo.
+- SSH on 22 is key-only (root disabled, passwords disabled).
+- `pedagogia` user owns `/opt/pedagogia/`; in the `docker` group.
+- `fail2ban` + `unattended-upgrades` enabled.
+- Hetzner firewall allows 22/80/443/ICMP; everything else denied.
+- Server only holds two mutable files: `/opt/pedagogia/docker-compose.prod.yml` and `/opt/pedagogia/.env.prod` (chmod 600). No source code; no secrets in git.
+
+### Images (two, both built in CI, pushed to GHCR, public)
+
+- `ghcr.io/yassinebenyaghlane/pedagogia-backend` — `prod/backend.Dockerfile`
+  Python 3.12 slim + uv, Django + Gunicorn (3 workers), non-root `app` uid 1000, `no-new-privileges`. Runs `backend/start.sh`.
+- `ghcr.io/yassinebenyaghlane/pedagogia-frontend` — `prod/frontend.Dockerfile`
+  Multi-stage: `node:22-alpine` builds the Vite bundle → `caddy:2-alpine` with the `dist/` in `/srv` and `prod/Caddyfile` baked at `/etc/caddy/Caddyfile`. Caddy handles TLS (ACME), HSTS, security headers, SPA fallback, and reverse proxy.
+
+Both images tagged `:latest` and `:sha-<commit>` on every push to `main`. Compose on the server pulls `:latest`.
+
+### Compose — `prod/docker-compose.prod.yml`
+
+Three services (`db`, `backend`, `frontend`), one bridge network (`backend_net`), three named volumes (`pgdata`, `caddy_data`, `caddy_config`). Every service has `env_file: .env.prod` — no `--env-file` flag on the CLI.
+
+- `db`: no host port (reachable only from `backend_net`).
+- `backend`: no host port either; `frontend` reverse-proxies to `backend:8000` inside the network.
+- `frontend`: the only service with host ports (`80`, `443/tcp`, `443/udp` for HTTP/3).
+
+### Traffic flow
+
+1. Browser → `https://collegia.be/` → Caddy terminates TLS.
+2. If path matches `/api/*`, `/admin/*`, `/static/*` → reverse-proxy to `backend:8000`.
+3. Otherwise → serve static file from `/srv`, falling back to `/index.html` for SPA routes.
+4. Django reads `X-Forwarded-Proto` via `SECURE_PROXY_SSL_HEADER` to know the scheme; issues secure cookies.
+
+### Security baseline
+
+- TLS: Let's Encrypt via Caddy (tls-alpn-01), auto-renewed. www.collegia.be 308 → apex.
+- Caddy headers: HSTS 1y + preload, X-Frame DENY, X-Content-Type-Options nosniff, Referrer-Policy same-origin, Permissions-Policy denies camera/mic/geo/FLoC, Cross-Origin-Opener-Policy same-origin, `Server` stripped.
+- Django (`backend/pedagogia/settings/prod.py`): `DEBUG=False`, required secrets validated at boot, `ALLOWED_HOSTS` scoped, `CSRF_TRUSTED_ORIGINS` scoped, `SESSION_COOKIE_SECURE` + `CSRF_COOKIE_SECURE` + `SameSite=Lax`, `SESSION_COOKIE_HTTPONLY`, `X_FRAME_OPTIONS=DENY`.
+- Containers: non-root, `no-new-privileges:true`, no privileged mode.
+- Secrets: generated fresh per env, never in git, `.env.prod` chmod 600, GHCR image contains zero secrets (everything from runtime env).
+
+### CI/CD
+
+- `.github/workflows/ci.yml` — on every PR + push to main: backend `ruff` + `pytest` (against a Postgres 16 service), frontend `eslint` + `vite build`.
+- `.github/workflows/deploy.yml` — on push to main: matrix-build both images, push to GHCR, SSH to server, `docker compose pull && up -d --remove-orphans && image prune -f`, smoke-check `/api/health/`.
+- All third-party actions pinned by commit SHA. Only `GITHUB_TOKEN` (ephemeral) is used to push to GHCR.
+- GitHub secrets required: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `DOMAIN`. No long-lived PATs.
+
+### Bootstrapping a new server
+
+See `prod/bootstrap.md`. Short version: `scp prod/docker-compose.prod.yml` to `/opt/pedagogia/`, write `.env.prod` from `prod/.env.prod.example`, `docker compose up -d`. First request to `https://<domain>/` triggers Caddy's ACME flow — make sure DNS points to the box beforehand.
+
+## Data model (core tables)
+
+```
+accounts_user ──┐
+                ├─ students_student ──┬─ sessions_session ── exercises_attempt
+                                      │
+                              skills_skill ─── skills_skillprerequisite
+                                 │
+                              exercises_exercisetemplate (JSONB params)
+```
+
+- Skill tree authored in `backend/src/skill_tree/skills.yaml`, seeded into DB.
+- Exercise templates authored in `backend/src/skill_tree/exercise_templates_p{1..6}.yaml`, stored as JSONB, instantiated at runtime.
+- Attempts link to a student + session + skill + template.
+
+## Dependencies on external services
+
+| Service | Purpose | Where configured |
+|---|---|---|
+| Anthropic Claude API | AI investigation on wrong answers | `ANTHROPIC_API_KEY`, `INVESTIGATION_MODEL_*` in `.env.prod` |
+| Google OAuth | social login | `GOOGLE_CLIENT_ID/SECRET` in `.env.prod`, redirect URI must be authorized in Google Console |
+| Let's Encrypt | TLS certs | Caddy owns this, `CADDY_EMAIL` in `.env.prod` |
+| GHCR | container registry | public packages, no pull auth on the server |
+
+## Out of scope of the POC architecture
+
+Automated DB backups, staging environment, blue/green deploys, Sentry, UptimeRobot, Cloudflare. All are single-PR additions later.

--- a/vault/wiki/concepts/prod-stack.md
+++ b/vault/wiki/concepts/prod-stack.md
@@ -1,0 +1,77 @@
+---
+title: Production stack
+type: concept
+created: 2026-04-17
+updated: 2026-04-17
+sources: []
+tags: [infra, deployment, docker, security]
+---
+
+How PedagogIA runs in production. Answers *"how is prod wired?"* without re-reading the Dockerfiles. Live instance: [[entities/collegia-be]]. Full repo-side map: `docs/architecture.md`.
+
+## Shape
+
+Two-image split on a single small VPS, everything inside Docker, Caddy in front.
+
+```
+Internet ──443/80─▶ frontend (Caddy)  ──internal:8000─▶ backend (Gunicorn)
+                        │                                  │
+                        │ serves SPA via try_files         │ Django
+                        │ reverse-proxies /api /admin      │ DRF + dj-rest-auth
+                        │ Let's Encrypt TLS                │
+                        └────────────────────┐             │
+                                             ▼             ▼
+                                          db (postgres:16, internal only)
+```
+
+- **`pedagogia-frontend`** — `caddy:2-alpine` with the Vite build baked into `/srv` + `prod/Caddyfile` at `/etc/caddy/Caddyfile`. Owns TLS (ACME via tls-alpn-01), HSTS, security headers, SPA `try_files {path} /index.html`, reverse_proxy of `/api/*` + `/admin/*` + `/static/*` → `backend:8000`. Only service with host ports (80, 443/tcp, 443/udp).
+- **`pedagogia-backend`** — `python:3.12-slim` + `uv`, Django + Gunicorn (3 workers, sync), non-root `app` uid 1000, `no-new-privileges`, runs `backend/start.sh` (which does `migrate` + `collectstatic` + `seed_skills` + `seed_templates` then `exec gunicorn`).
+- **`db`** — `postgres:16-alpine`, internal-only (no host port). Named volume `pgdata` on the host.
+
+All three share one docker bridge network (`backend_net`). Every service has `env_file: .env.prod` so there's no `--env-file` flag on CLI commands.
+
+## Why two images, not one
+
+Rejected designs:
+
+- Single image where Django+WhiteNoise serves both API and SPA. Needed a Django SPA-fallback view to make deep links refresh without 404s — coupling the frontend routes to a Django URL pattern. Rejected: messy boundary.
+- Separate Caddy container as a pure proxy, with the SPA dist shared from the backend image via a volume. Rejected: volume seeding only works on first attach, so deploys wouldn't refresh the dist without wiping the volume.
+
+Current split (frontend image = Caddy + dist) puts SPA routing where it belongs (Caddy), keeps backend purely an API, and both images are independently versioned and immutable.
+
+## CI/CD
+
+- `.github/workflows/ci.yml` — PR + push to main: backend `ruff` + `pytest` (against a real Postgres 16 service), frontend `eslint` + `vite build`.
+- `.github/workflows/deploy.yml` — push to main: matrix-build both images, push `:latest` + `:sha-<commit>` to GHCR, SSH to server, `docker compose pull && up -d --remove-orphans && image prune -f`, smoke-check `/api/health/` via HTTPS.
+- Third-party actions **pinned by commit SHA** (Dependabot bumps them safely). Only `GITHUB_TOKEN` (ephemeral, scoped `packages: write`) pushes to GHCR — no long-lived PAT.
+- GH secrets: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `DOMAIN`.
+
+## Server baseline
+
+- Hetzner cx23 (cost_optimized, 2c/4GB/40GB, €3.99/mo) in `nbg1`, Ubuntu 24.04.
+- Hetzner firewall: 22, 80, 443, ICMP only. Everything else denied at network boundary.
+- SSH: key-only, root login disabled, password auth disabled.
+- `pedagogia` user (uid 1000) owns `/opt/pedagogia/`; member of `docker` group.
+- `fail2ban` + `unattended-upgrades` enabled.
+- Server holds only two mutable files: `/opt/pedagogia/docker-compose.prod.yml` + `/opt/pedagogia/.env.prod` (chmod 600). No source code, no secrets in git.
+
+## Security baseline
+
+- **TLS**: Caddy auto-obtains and auto-renews Let's Encrypt certs (tls-alpn-01). `www.<domain>` 308 → apex.
+- **Headers** (Caddy): HSTS 1y + preload, `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: same-origin`, `Permissions-Policy` denies camera/mic/geolocation/FLoC, `Cross-Origin-Opener-Policy: same-origin`, `Server` stripped.
+- **Django** (`backend/pedagogia/settings/prod.py`): `DEBUG=False`, required secrets validated at boot, `ALLOWED_HOSTS` scoped (domain + `localhost` for in-container healthcheck), `CSRF_TRUSTED_ORIGINS` scoped, `SESSION_COOKIE_SECURE`, `CSRF_COOKIE_SECURE`, `SESSION_COOKIE_HTTPONLY`, `SameSite=Lax`, `X_FRAME_OPTIONS=DENY`, `SECURE_PROXY_SSL_HEADER=("HTTP_X_FORWARDED_PROTO","https")`. Gunicorn trusts forwarded headers only from localhost (narrow default).
+- **Containers**: non-root (uid 1000), `no-new-privileges:true`, no privileged mode, read-only where feasible.
+- **Secrets**: generated per-env (`secrets.token_urlsafe(64)` for Django, `openssl rand -base64 32` for Postgres), never in git, `.env.prod` chmod 600 on the server, zero secrets baked into images.
+
+## Out of scope (follow-ups)
+
+Automated Postgres backups, staging environment, Sentry, UptimeRobot, Cloudflare (origin hiding + DDoS + CDN), rate limiting on `/api/auth/login`, email verification before real users, blue/green deploys. All are single-PR additions once the POC validates.
+
+## Common ops
+
+Mutating prod is rare (the pipeline does it); when you need to, SSH as `pedagogia@<server>` and `cd /opt/pedagogia`. To pick up new `.env.prod` values: `docker compose -f docker-compose.prod.yml up -d --force-recreate <service>` (`restart` alone doesn't re-read `env_file`). To wipe state: `docker compose down -v` (destroys `pgdata` — only after backing up).
+
+## See also
+
+- [[entities/collegia-be]] — the live production deployment
+- [[overview]] — top-level project synthesis

--- a/vault/wiki/entities/collegia-be.md
+++ b/vault/wiki/entities/collegia-be.md
@@ -1,0 +1,52 @@
+---
+title: collegia.be
+type: entity
+created: 2026-04-17
+updated: 2026-04-17
+sources: []
+tags: [infra, deployment, prod]
+---
+
+The live production deployment of PedagogIA. Pattern it instantiates: [[concepts/prod-stack]].
+
+## Summary
+
+Single Hetzner VPS hosting the PedagogIA POC under the domain `collegia.be`. Went live 2026-04-17. First production environment for the project.
+
+## Current state (2026-04-17)
+
+- **Host**: Hetzner Cloud cx23 (`collegia-prod`), `nbg1`, Ubuntu 24.04, €3.99/mo.
+- **IPv4**: `46.225.142.212`
+- **IPv6**: `2a01:4f8:c0c:1dbf::1`
+- **Firewall**: Hetzner `pedagogia-web` (22/80/443/ICMP).
+- **SSH users**: `pedagogia` (operator, operations), plus a CI deploy key (GH Actions). Root disabled, password auth disabled.
+- **Images**:
+  - `ghcr.io/yassinebenyaghlane/pedagogia-backend:latest`
+  - `ghcr.io/yassinebenyaghlane/pedagogia-frontend:latest`
+  Both public (GHCR package visibility set).
+- **DNS**: apex + `www` A/AAAA at LWS → Hetzner IPs (TTL 6h).
+- **TLS**: Let's Encrypt via Caddy (tls-alpn-01). Auto-renews.
+- **Mail**: LWS keeps `mail.collegia.be` and `A mail` + `CNAME imap/pop/smtp/ftp`. Unrelated to the app; left alone.
+
+## GitHub integration
+
+- Repo: `YassineBenYaghlane/PedagogIA` (public).
+- Actions secrets: `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY`, `DOMAIN`. No PATs; GHCR pushes use `GITHUB_TOKEN`.
+- Deploy workflow SSHes as `pedagogia@46.225.142.212` on every push to `main`.
+
+## Relationships
+
+- Implements: [[concepts/prod-stack]]
+- Depends on: Anthropic Claude API, Google OAuth, Let's Encrypt, GHCR
+- Runbook: `prod/bootstrap.md` in the repo
+
+## Open threads
+
+- Google OAuth redirect URIs not yet added in Google Console (tracked in GitHub issue #91).
+- Postgres automated backups: not yet configured.
+- Sentry / UptimeRobot / Cloudflare: explicitly deferred.
+
+## See also
+
+- [[concepts/prod-stack]]
+- [[overview]]

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -14,10 +14,10 @@ Catalog of every wiki page. Updated on every ingest. Keep lines ≤150 chars.
 *(none yet — drop files into `raw/` and ask to ingest)*
 
 ## Entities
-*(none yet)*
+- [[entities/collegia-be]] — the live production deployment on Hetzner (IPs, images, GH wiring)
 
 ## Concepts
-*(none yet)*
+- [[concepts/prod-stack]] — how prod is wired: two-image Docker split, Caddy front, CI/CD, security baseline
 
 ## Questions
 *(none yet)*

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -10,3 +10,7 @@ Append-only chronological record. Every entry starts with `## [YYYY-MM-DD] <verb
 ## [2026-04-17] bootstrap | Wiki created
 
 Initialized the PedagogIA LLM wiki at `~/vault/pedagogia/`. Wrote `CLAUDE.md` (schema & workflows), `README.md` (human quick reference), and empty skeletons for `wiki/index.md`, `wiki/overview.md`, and category folders (`sources/`, `entities/`, `concepts/`, `questions/`). Ready to ingest sources.
+
+## [2026-04-17] ingest | Production architecture (collegia.be)
+
+First technical ingest. Filed [[concepts/prod-stack]] (two-image Docker split, Caddy front for TLS+SPA+API proxy, Hetzner cx23, CI/CD via GH Actions → GHCR → SSH, security baseline) and [[entities/collegia-be]] (live instance at `46.225.142.212`, current images, DNS at LWS, deploy SSH setup). Source: the repo's new `docs/architecture.md` and `prod/` directory (PR #85 + #90). Updated `index.md` and `overview.md` to reflect the new pages; no contradictions with prior claims (wiki was effectively empty).

--- a/vault/wiki/overview.md
+++ b/vault/wiki/overview.md
@@ -25,8 +25,9 @@ The wiki is not the codebase — `CLAUDE.md` at the repo root covers the code. T
 
 ## Current state
 
-Wiki bootstrapped on 2026-04-17. No sources ingested yet. Structure and conventions defined in [[../CLAUDE|CLAUDE.md]].
+Wiki bootstrapped on 2026-04-17. First filings are infra-flavored: [[concepts/prod-stack]] and [[entities/collegia-be]]. Production went live the same day at `https://collegia.be` on a Hetzner cx23, Docker two-image split behind Caddy, CI/CD via GH Actions → GHCR → SSH. Structure and conventions defined in [[../CLAUDE|CLAUDE.md]].
 
 ## Open threads
 
-*(placeholder — populated as sources come in and themes emerge)*
+- Google OAuth prod setup (tracked as issue #91).
+- Pedagogical sources: no FWB / didactique material ingested yet — drop into `raw/` and ingest as material accumulates.


### PR DESCRIPTION
Follow-up to #22 / #85 / #90. Now that prod is live at `https://collegia.be`, documenting the architecture so future sessions (human or LLM) don't re-derive it from the Dockerfiles each time.

## Summary

- **`docs/architecture.md`** — canonical dev + prod map. Services, traffic flow, security baseline, CI/CD, data model, out-of-scope list.
- **`CLAUDE.md`** — new *Production* section pointing at `docs/architecture.md` and `prod/bootstrap.md`. Open-work line adjusted now that prod is live.
- **`vault/wiki/`** — two new pages filed via the `pedagogia-wiki` skill's ingest flow: `concepts/prod-stack.md` (the pattern) and `entities/collegia-be.md` (the live instance). Index, overview, and log updated.
- **`.claude/skills/prod-ops/`** — new operational skill, triggers on "prod" / "server" / "deploy" / "redeploy" / "rollback" / French variants. Captures the non-obvious gotchas: `docker compose restart` doesn't re-read `env_file` (must `up -d --force-recreate`), GHCR package visibility, Caddy cert dance. Points at the architecture doc for the *why* rather than duplicating it.

No code changes. No secrets touched.

## Test plan
- [ ] CI green (lint-only — nothing it can meaningfully test)
- [ ] After merge, a new Claude session asking "how is prod wired?" or "check the prod logs" picks up the `prod-ops` / `pedagogia-wiki` skills and answers without re-reading Dockerfiles