### PR TITLE
feat(#93): parent overview endpoint

### DIFF
--- a/backend/apps/sessions/exports.py
+++ b/backend/apps/sessions/exports.py
@@ -1,9 +1,11 @@
 """Per-student exports: sessions summary, PDF report card, JSON dump."""
 
 from collections import defaultdict
+from datetime import datetime, time, timedelta
 from io import BytesIO
 
 from django.db.models import Count, Q
+from django.db.models.functions import TruncDate
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -71,6 +73,52 @@ def session_summaries(student: Student) -> list[dict]:
             }
         )
     return out
+
+
+def daily_activity_summary(student: Student, days: int = 7) -> dict:
+    """Aggregate attempts over the last N days (inclusive of today) in Brussels-local dates."""
+    from apps.students.services.streaks import BRUSSELS, brussels_today
+
+    today = brussels_today()
+    start_day = today - timedelta(days=days - 1)
+    start_dt = datetime.combine(start_day, time.min).replace(tzinfo=BRUSSELS)
+
+    attempts = Attempt.objects.filter(session__student=student, responded_at__gte=start_dt)
+    session_count = (
+        Session.objects.filter(student=student, started_at__gte=start_dt).distinct().count()
+    )
+
+    rows = (
+        attempts.annotate(day=TruncDate("responded_at", tzinfo=BRUSSELS))
+        .values("day")
+        .annotate(n=Count("id"), correct=Count("id", filter=Q(is_correct=True)))
+    )
+    by_day_map = {r["day"]: r for r in rows}
+
+    by_day = []
+    total_attempts = 0
+    total_correct = 0
+    for i in range(days):
+        day = start_day + timedelta(days=i)
+        row = by_day_map.get(day)
+        n = row["n"] if row else 0
+        correct = row["correct"] if row else 0
+        by_day.append(
+            {
+                "date": day.isoformat(),
+                "attempts": n,
+                "accuracy": round(correct / n, 2) if n else 0.0,
+            }
+        )
+        total_attempts += n
+        total_correct += correct
+
+    return {
+        "sessions": session_count,
+        "attempts": total_attempts,
+        "accuracy": round(total_correct / total_attempts, 2) if total_attempts else 0.0,
+        "by_day": by_day,
+    }
 
 
 def build_full_json(student: Student) -> dict:

--- a/backend/apps/students/urls.py
+++ b/backend/apps/students/urls.py
@@ -1,8 +1,13 @@
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .views import StudentViewSet
+from .views_parent import ParentOverviewView
 
 router = DefaultRouter()
 router.register(r"students", StudentViewSet, basename="student")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("parent/overview/", ParentOverviewView.as_view(), name="parent-overview"),
+    *router.urls,
+]

--- a/backend/apps/students/views_parent.py
+++ b/backend/apps/students/views_parent.py
@@ -1,0 +1,42 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.sessions.exports import daily_activity_summary, session_summaries
+from apps.students.services.streaks import daily_progress
+
+from .models import Student
+from .serializers import mastery_counts
+
+
+def _student_payload(student: Student) -> dict:
+    return {
+        "id": str(student.id),
+        "display_name": student.display_name,
+        "grade": student.grade,
+        "created_at": student.created_at.isoformat() if student.created_at else None,
+        "gamification": {
+            "xp": student.xp,
+            "rank": student.rank,
+            "current_streak": student.current_streak,
+            "best_streak": student.best_streak,
+            "last_activity_date": (
+                student.last_activity_date.isoformat() if student.last_activity_date else None
+            ),
+            "daily_goal": student.daily_goal,
+            "daily_progress": daily_progress(student),
+        },
+        "mastery_summary": mastery_counts(student),
+        "recent_sessions": session_summaries(student)[:5],
+        "last_7_days": daily_activity_summary(student, days=7),
+    }
+
+
+class ParentOverviewView(APIView):
+    """Aggregated overview of every student on the authenticated account."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        students = Student.objects.filter(user=request.user).order_by("display_name")
+        return Response({"students": [_student_payload(s) for s in students]})

--- a/backend/tests/test_parent_overview.py
+++ b/backend/tests/test_parent_overview.py
@@ -1,0 +1,169 @@
+"""GET /api/parent/overview/ — account-wide dashboard payload."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+
+@pytest.mark.django_db
+def test_overview_requires_auth(api):
+    res = api.get("/api/parent/overview/")
+    assert res.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_overview_empty_account(auth_client):
+    res = auth_client.get("/api/parent/overview/")
+    assert res.status_code == 200
+    assert res.json() == {"students": []}
+
+
+@pytest.mark.django_db
+def test_overview_shape(auth_client):
+    auth_client.post("/api/students/", {"display_name": "Léo", "grade": "P2"}, format="json")
+
+    res = auth_client.get("/api/parent/overview/")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["students"]) == 1
+    s = body["students"][0]
+
+    assert set(s.keys()) >= {
+        "id",
+        "display_name",
+        "grade",
+        "created_at",
+        "gamification",
+        "mastery_summary",
+        "recent_sessions",
+        "last_7_days",
+    }
+    assert s["display_name"] == "Léo"
+    assert s["grade"] == "P2"
+
+    gami = s["gamification"]
+    assert set(gami.keys()) == {
+        "xp",
+        "rank",
+        "current_streak",
+        "best_streak",
+        "last_activity_date",
+        "daily_goal",
+        "daily_progress",
+    }
+
+    mastery = s["mastery_summary"]
+    assert set(mastery.keys()) == {"not_started", "in_progress", "mastered", "needs_review"}
+
+    assert s["recent_sessions"] == []
+
+    week = s["last_7_days"]
+    assert set(week.keys()) == {"sessions", "attempts", "accuracy", "by_day"}
+    assert len(week["by_day"]) == 7
+    assert all(d["attempts"] == 0 for d in week["by_day"])
+
+
+@pytest.mark.django_db
+def test_overview_sorted_by_display_name(auth_client):
+    auth_client.post("/api/students/", {"display_name": "Zoé", "grade": "P1"}, format="json")
+    auth_client.post("/api/students/", {"display_name": "Ana", "grade": "P1"}, format="json")
+    auth_client.post("/api/students/", {"display_name": "Milo", "grade": "P1"}, format="json")
+
+    res = auth_client.get("/api/parent/overview/")
+    names = [s["display_name"] for s in res.json()["students"]]
+    assert names == ["Ana", "Milo", "Zoé"]
+
+
+@pytest.mark.django_db
+def test_overview_scoped_to_requesting_user(auth_client, other_user, api):
+    auth_client.post("/api/students/", {"display_name": "Mine", "grade": "P1"}, format="json")
+
+    from apps.students.models import Student
+
+    Student.objects.create(user=other_user, display_name="Theirs", grade="P3")
+
+    res = auth_client.get("/api/parent/overview/")
+    names = [s["display_name"] for s in res.json()["students"]]
+    assert names == ["Mine"]
+
+    api.force_authenticate(other_user)
+    res = api.get("/api/parent/overview/")
+    names = [s["display_name"] for s in res.json()["students"]]
+    assert names == ["Theirs"]
+
+
+@pytest.mark.django_db
+def test_overview_reflects_attempts_in_last_7_days(auth_client):
+    from apps.exercises.models import Attempt, ExerciseTemplate
+    from apps.sessions.models import Session
+    from apps.students.models import Student
+
+    student_id = auth_client.post(
+        "/api/students/", {"display_name": "Eva", "grade": "P1"}, format="json"
+    ).json()["id"]
+    student = Student.objects.get(id=student_id)
+
+    session = Session.objects.create(student=student, mode="learn")
+    template = ExerciseTemplate.objects.first()
+    Attempt.objects.create(
+        session=session,
+        skill=template.skill,
+        template=template,
+        input_type="number",
+        exercise_params={},
+        student_answer="1",
+        correct_answer="1",
+        is_correct=True,
+    )
+    Attempt.objects.create(
+        session=session,
+        skill=template.skill,
+        template=template,
+        input_type="number",
+        exercise_params={},
+        student_answer="2",
+        correct_answer="3",
+        is_correct=False,
+    )
+
+    res = auth_client.get("/api/parent/overview/")
+    s = res.json()["students"][0]
+    week = s["last_7_days"]
+    assert week["attempts"] == 2
+    assert week["accuracy"] == 0.5
+    assert week["sessions"] == 1
+
+    today = week["by_day"][-1]
+    assert today["attempts"] == 2
+    assert today["accuracy"] == 0.5
+
+
+@pytest.mark.django_db
+def test_overview_ignores_attempts_older_than_7_days(auth_client):
+    from apps.exercises.models import Attempt, ExerciseTemplate
+    from apps.sessions.models import Session
+    from apps.students.models import Student
+
+    student_id = auth_client.post(
+        "/api/students/", {"display_name": "Old", "grade": "P1"}, format="json"
+    ).json()["id"]
+    student = Student.objects.get(id=student_id)
+
+    session = Session.objects.create(student=student, mode="learn")
+    template = ExerciseTemplate.objects.first()
+    old = Attempt.objects.create(
+        session=session,
+        skill=template.skill,
+        template=template,
+        input_type="number",
+        exercise_params={},
+        student_answer="1",
+        correct_answer="1",
+        is_correct=True,
+    )
+    Attempt.objects.filter(pk=old.pk).update(responded_at=timezone.now() - timedelta(days=30))
+
+    res = auth_client.get("/api/parent/overview/")
+    week = res.json()["students"][0]["last_7_days"]
+    assert week["attempts"] == 0


### PR DESCRIPTION
Closes #93.

## Summary
- New `GET /api/parent/overview/` returning `{ students: [...] }` for the authenticated user, one entry per owned student.
- Each entry includes: identity (`id`, `display_name`, `grade`), `gamification` (xp, rank, streaks, daily goal/progress, last_activity_date), `mastery_summary` (status counts), `recent_sessions` (last 5 via existing `session_summaries`), `last_7_days` (sessions, attempts, overall accuracy, per-day breakdown).
- New helper `daily_activity_summary(student, days=7)` in `apps/sessions/exports.py` — groups attempts by Brussels-local date using `TruncDate`.
- Pure aggregation — no new models, no migration.
- Scoping: `IsAuthenticated` + `Student.objects.filter(user=request.user)`. A second account sees zero overlap.

Powers the upcoming parent dashboard screen (`/dashboard`) — that ships as a separate PR.

## Test plan
- [x] `uv run pytest tests/test_parent_overview.py -v` — 7 new tests covering auth, empty account, payload shape, sort order, user scoping (no leakage between accounts), 7-day aggregation with fresh attempts, 7-day window excludes older attempts.
- [x] `uv run pytest --reuse-db` — full suite: 137 passed (no regressions).
- [x] `uv run ruff check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)