### PR TITLE
feat(#64): nightly encrypted Postgres backups to Hetzner Storage Box

### DIFF
--- a/deploy/restore.md
+++ b/deploy/restore.md
@@ -1,0 +1,79 @@
+# Restoring a PedagogIA Postgres backup
+
+Backups are encrypted with [age](https://age-encryption.org) and live on the Hetzner Storage Box `pedagogia-backups` (`u578869.your-storagebox.de`, location `fsn1`). Three buckets: `daily/` (7 kept), `weekly/` (4), `monthly/` (3). See `.env.prod` on the VPS for connection env; private age key lives only in 1Password ("collegia — storage box + backup keys").
+
+## 1. Pick and download a dump
+
+From your laptop (any Mac/Linux with SSH + age):
+
+```bash
+# List what's available
+sftp -i ~/.ssh/id_ed25519 -P 23 u578869@u578869.your-storagebox.de <<<"ls -1 daily"
+
+# Download the one you want
+sftp -i ~/.ssh/id_ed25519 -P 23 u578869@u578869.your-storagebox.de:daily/pedagogia-20260418T030000Z.dump.age .
+```
+
+## 2. Decrypt
+
+```bash
+# Put the private key file somewhere temporary (600 perms)
+echo "AGE-SECRET-KEY-1…" > /tmp/age_key.txt && chmod 600 /tmp/age_key.txt
+
+age -d -i /tmp/age_key.txt -o pedagogia.dump pedagogia-20260418T030000Z.dump.age
+rm /tmp/age_key.txt
+```
+
+## 3. Restore into a fresh Postgres
+
+### Option A — restore into the live prod stack (in place)
+
+Only if the DB is already broken or empty. **This overwrites data.** Stop the backend first so no writes race the restore.
+
+```bash
+scp pedagogia.dump pedagogia@46.225.142.212:/tmp/
+ssh pedagogia@46.225.142.212
+cd /opt/pedagogia
+docker compose -f docker-compose.prod.yml stop backend
+docker compose -f docker-compose.prod.yml exec -T db \
+  pg_restore -U pedagogia -d pedagogia --clean --if-exists < /tmp/pedagogia.dump
+docker compose -f docker-compose.prod.yml start backend
+rm /tmp/pedagogia.dump
+```
+
+### Option B — restore into a fresh disposable container (verification)
+
+Use this for the quarterly dry-run. Run locally on your laptop:
+
+```bash
+docker run -d --name pg-restore-test \
+  -e POSTGRES_USER=pedagogia -e POSTGRES_PASSWORD=pedagogia -e POSTGRES_DB=pedagogia \
+  -p 55432:5432 postgres:16-alpine
+
+# wait for pg to be ready
+until docker exec pg-restore-test pg_isready -U pedagogia; do sleep 1; done
+
+docker exec -i pg-restore-test pg_restore -U pedagogia -d pedagogia --clean --if-exists < pedagogia.dump
+
+# sanity: how many students/skills/attempts came back
+docker exec pg-restore-test psql -U pedagogia -d pedagogia -c \
+  "SELECT 'students' t, count(*) FROM students_student
+   UNION ALL SELECT 'skills', count(*) FROM skills_skill
+   UNION ALL SELECT 'attempts', count(*) FROM exercises_attempt;"
+
+docker rm -f pg-restore-test
+```
+
+## 4. Verification checklist after a real restore
+
+- [ ] Backend container is healthy (`docker compose ps`)
+- [ ] `curl https://collegia.be/api/health/` returns 200
+- [ ] Log in as the operator user and see your children on `/enfants`
+- [ ] Open a child, confirm skill tree loads and mastery state looks right
+- [ ] Attempt one exercise; no 500s in `docker logs pedagogia-backend-1 --tail 50`
+
+## 5. Incident note
+
+After any real restore (not a dry-run), append a short entry to
+`vault/wiki/log.md` (`## [YYYY-MM-DD] note | restored prod DB from <filename>`)
+so the next operator has the timeline.

--- a/prod/backup.sh
+++ b/prod/backup.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Nightly Postgres backup to Hetzner Storage Box, encrypted with age.
+# Invoked by cron (or pedagogia-backup.service under systemd).
+# Loads env from /opt/pedagogia/.env.prod and prepends ~/bin to PATH.
+
+ENV_FILE=${ENV_FILE:-/opt/pedagogia/.env.prod}
+[ -r "$ENV_FILE" ] && set -a && . "$ENV_FILE" && set +a
+export PATH="$HOME/bin:$PATH"
+
+: "${POSTGRES_DB:?}"
+: "${POSTGRES_USER:?}"
+: "${STORAGE_BOX_HOST:?}"
+: "${STORAGE_BOX_USER:?}"
+: "${BACKUP_AGE_RECIPIENT:?}"
+
+COMPOSE_FILE=${COMPOSE_FILE:-/opt/pedagogia/docker-compose.prod.yml}
+LOCAL_DIR=${LOCAL_DIR:-/home/pedagogia/backups}
+SSH_KEY=${SSH_KEY:-/home/pedagogia/.ssh/storagebox_ed25519}
+RETENTION_DAILY=${RETENTION_DAILY:-7}
+RETENTION_WEEKLY=${RETENTION_WEEKLY:-4}
+RETENTION_MONTHLY=${RETENTION_MONTHLY:-3}
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+BASENAME="pedagogia-${TS}.dump.age"
+DUMP="$LOCAL_DIR/pedagogia-${TS}.dump"
+ENC="$LOCAL_DIR/$BASENAME"
+mkdir -p "$LOCAL_DIR"
+
+cleanup() { rm -f "$DUMP" "$ENC"; }
+trap cleanup EXIT
+
+echo "[$(date -u +%FT%TZ)] dump start"
+docker compose -f "$COMPOSE_FILE" exec -T db \
+  pg_dump -U "$POSTGRES_USER" -d "$POSTGRES_DB" -Fc > "$DUMP"
+echo "[$(date -u +%FT%TZ)] dump done ($(stat -c%s "$DUMP") bytes)"
+
+age -r "$BACKUP_AGE_RECIPIENT" -o "$ENC" "$DUMP"
+rm "$DUMP"
+echo "[$(date -u +%FT%TZ)] encrypted ($(stat -c%s "$ENC") bytes)"
+
+BUCKETS=(daily)
+[ "$(date -u +%u)" = "7" ] && BUCKETS+=(weekly)
+[ "$(date -u +%d)" = "01" ] && BUCKETS+=(monthly)
+
+SFTP="sftp -i $SSH_KEY -P 23 -o StrictHostKeyChecking=accept-new -o BatchMode=yes ${STORAGE_BOX_USER}@${STORAGE_BOX_HOST}"
+
+{
+  for b in "${BUCKETS[@]}"; do echo "-mkdir $b"; done
+  for b in "${BUCKETS[@]}"; do echo "put $ENC $b/$BASENAME"; done
+  echo bye
+} | $SFTP
+echo "[$(date -u +%FT%TZ)] uploaded to: ${BUCKETS[*]}"
+
+prune_bucket() {
+  local bucket=$1 keep=$2
+  local listing
+  listing=$(printf "cd %s\nls -1\nbye\n" "$bucket" | $SFTP 2>/dev/null \
+    | grep -E '^pedagogia-[0-9TZ]+\.dump\.age$' | sort || true)
+  local total; total=$(printf "%s\n" "$listing" | grep -c . || true)
+  if [ "$total" -le "$keep" ]; then return; fi
+  local victims
+  victims=$(printf "%s\n" "$listing" | head -n "$((total - keep))")
+  {
+    for v in $victims; do echo "rm $bucket/$v"; done
+    echo bye
+  } | $SFTP
+  echo "[$(date -u +%FT%TZ)] pruned $bucket: $(echo "$victims" | wc -l | tr -d ' ') file(s)"
+}
+
+prune_bucket daily   "$RETENTION_DAILY"
+prune_bucket weekly  "$RETENTION_WEEKLY"
+prune_bucket monthly "$RETENTION_MONTHLY"
+
+echo "[$(date -u +%FT%TZ)] backup complete"

--- a/prod/bootstrap.md
+++ b/prod/bootstrap.md
@@ -84,3 +84,32 @@ In Google Cloud Console → Credentials → the OAuth 2.0 client:
 
 Push to `main` → GH Actions builds both images → pushes to GHCR → SSHes
 here → `pull && up -d --remove-orphans`. No manual steps after this.
+
+## 8. Nightly Postgres backups
+
+Backups go to the Hetzner Storage Box `pedagogia-backups` (`u578869.your-storagebox.de`, `fsn1`), encrypted with [age](https://age-encryption.org). Retention 7 daily + 4 weekly + 3 monthly. Restore runbook: [`deploy/restore.md`](../deploy/restore.md). Runs via user cron (no sudo required — the `pedagogia` account doesn't have passwordless sudo).
+
+```bash
+# On the VPS, as pedagogia:
+ssh-keygen -t ed25519 -f ~/.ssh/storagebox_ed25519 -N "" -C "pedagogia-vps-backup"
+# Register the public key with the Storage Box via `hcloud storage-box update --ssh-key ...` from the laptop.
+
+mkdir -p ~/bin ~/backups
+cd /tmp && curl -fsSL https://github.com/FiloSottile/age/releases/download/v1.2.0/age-v1.2.0-linux-amd64.tar.gz \
+  | tar -xz && mv age/age age/age-keygen ~/bin/ && rm -rf age
+
+# Append to /opt/pedagogia/.env.prod:
+#   STORAGE_BOX_HOST=u578869.your-storagebox.de
+#   STORAGE_BOX_USER=u578869
+#   BACKUP_AGE_RECIPIENT=<age public key from 1Password>
+
+# scp backup.sh from repo to /opt/pedagogia/backup.sh, chmod +x.
+
+# Install cron entry:
+(crontab -l 2>/dev/null; echo "0 3 * * * /opt/pedagogia/backup.sh >> /home/pedagogia/backup.log 2>&1") | crontab -
+
+# Verify with a manual run:
+/opt/pedagogia/backup.sh
+```
+
+Age private key is **not** stored on the VPS — it lives in 1Password ("collegia — storage box + backup keys"). Losing it means the existing dumps become unrecoverable. Losing the VPS does not affect dumps; losing Hetzner Falkenstein does not affect the server.


### PR DESCRIPTION
## Summary
- Nightly `pg_dump` → `age` encrypt → SFTP to Hetzner Storage Box `pedagogia-backups` (fsn1, offsite from nbg1)
- Retention: 7 daily + 4 weekly + 3 monthly, enforced per-bucket
- Runs via `pedagogia` user crontab (no sudo — account has none)
- Restore runbook at `deploy/restore.md` — verified end-to-end with a throwaway keypair (110 skills + 29 attempts round-tripped into a disposable container)

Closes #64.

## Test plan
- [x] Manual `/opt/pedagogia/backup.sh` run produced `daily/pedagogia-20260417T214756Z.dump.age` on the Storage Box (97729 bytes)
- [x] Decrypt → `pg_restore` into `postgres:16-alpine` container succeeds; row counts match prod
- [x] `crontab -l` on the VPS shows the nightly entry (`0 3 * * * /opt/pedagogia/backup.sh …`)
- [ ] User verifies their 1Password-saved age private key decrypts a real backup (5-sec one-liner in the PR comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)