### PR TITLE
feat(#96): parent dashboard screen at /dashboard

### DIFF
--- a/backend/apps/sessions/exports.py
+++ b/backend/apps/sessions/exports.py
@@ -1,9 +1,11 @@
 """Per-student exports: sessions summary, PDF report card, JSON dump."""
 
 from collections import defaultdict
+from datetime import datetime, time, timedelta
 from io import BytesIO
 
 from django.db.models import Count, Q
+from django.db.models.functions import TruncDate
 from reportlab.lib import colors
 from reportlab.lib.pagesizes import A4
 from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
@@ -71,6 +73,52 @@ def session_summaries(student: Student) -> list[dict]:
             }
         )
     return out
+
+
+def daily_activity_summary(student: Student, days: int = 7) -> dict:
+    """Aggregate attempts over the last N days (inclusive of today) in Brussels-local dates."""
+    from apps.students.services.streaks import BRUSSELS, brussels_today
+
+    today = brussels_today()
+    start_day = today - timedelta(days=days - 1)
+    start_dt = datetime.combine(start_day, time.min).replace(tzinfo=BRUSSELS)
+
+    attempts = Attempt.objects.filter(session__student=student, responded_at__gte=start_dt)
+    session_count = (
+        Session.objects.filter(student=student, started_at__gte=start_dt).distinct().count()
+    )
+
+    rows = (
+        attempts.annotate(day=TruncDate("responded_at", tzinfo=BRUSSELS))
+        .values("day")
+        .annotate(n=Count("id"), correct=Count("id", filter=Q(is_correct=True)))
+    )
+    by_day_map = {r["day"]: r for r in rows}
+
+    by_day = []
+    total_attempts = 0
+    total_correct = 0
+    for i in range(days):
+        day = start_day + timedelta(days=i)
+        row = by_day_map.get(day)
+        n = row["n"] if row else 0
+        correct = row["correct"] if row else 0
+        by_day.append(
+            {
+                "date": day.isoformat(),
+                "attempts": n,
+                "accuracy": round(correct / n, 2) if n else 0.0,
+            }
+        )
+        total_attempts += n
+        total_correct += correct
+
+    return {
+        "sessions": session_count,
+        "attempts": total_attempts,
+        "accuracy": round(total_correct / total_attempts, 2) if total_attempts else 0.0,
+        "by_day": by_day,
+    }
 
 
 def build_full_json(student: Student) -> dict:

--- a/backend/apps/students/urls.py
+++ b/backend/apps/students/urls.py
@@ -1,8 +1,13 @@
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
 from .views import StudentViewSet
+from .views_parent import ParentOverviewView
 
 router = DefaultRouter()
 router.register(r"students", StudentViewSet, basename="student")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("parent/overview/", ParentOverviewView.as_view(), name="parent-overview"),
+    *router.urls,
+]

--- a/backend/apps/students/views_parent.py
+++ b/backend/apps/students/views_parent.py
@@ -1,0 +1,42 @@
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.sessions.exports import daily_activity_summary, session_summaries
+from apps.students.services.streaks import daily_progress
+
+from .models import Student
+from .serializers import mastery_counts
+
+
+def _student_payload(student: Student) -> dict:
+    return {
+        "id": str(student.id),
+        "display_name": student.display_name,
+        "grade": student.grade,
+        "created_at": student.created_at.isoformat() if student.created_at else None,
+        "gamification": {
+            "xp": student.xp,
+            "rank": student.rank,
+            "current_streak": student.current_streak,
+            "best_streak": student.best_streak,
+            "last_activity_date": (
+                student.last_activity_date.isoformat() if student.last_activity_date else None
+            ),
+            "daily_goal": student.daily_goal,
+            "daily_progress": daily_progress(student),
+        },
+        "mastery_summary": mastery_counts(student),
+        "recent_sessions": session_summaries(student)[:5],
+        "last_7_days": daily_activity_summary(student, days=7),
+    }
+
+
+class ParentOverviewView(APIView):
+    """Aggregated overview of every student on the authenticated account."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        students = Student.objects.filter(user=request.user).order_by("display_name")
+        return Response({"students": [_student_payload(s) for s in students]})

--- a/backend/tests/test_parent_overview.py
+++ b/backend/tests/test_parent_overview.py
@@ -1,0 +1,169 @@
+"""GET /api/parent/overview/ — account-wide dashboard payload."""
+
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+
+@pytest.mark.django_db
+def test_overview_requires_auth(api):
+    res = api.get("/api/parent/overview/")
+    assert res.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+def test_overview_empty_account(auth_client):
+    res = auth_client.get("/api/parent/overview/")
+    assert res.status_code == 200
+    assert res.json() == {"students": []}
+
+
+@pytest.mark.django_db
+def test_overview_shape(auth_client):
+    auth_client.post("/api/students/", {"display_name": "Léo", "grade": "P2"}, format="json")
+
+    res = auth_client.get("/api/parent/overview/")
+    assert res.status_code == 200
+    body = res.json()
+    assert len(body["students"]) == 1
+    s = body["students"][0]
+
+    assert set(s.keys()) >= {
+        "id",
+        "display_name",
+        "grade",
+        "created_at",
+        "gamification",
+        "mastery_summary",
+        "recent_sessions",
+        "last_7_days",
+    }
+    assert s["display_name"] == "Léo"
+    assert s["grade"] == "P2"
+
+    gami = s["gamification"]
+    assert set(gami.keys()) == {
+        "xp",
+        "rank",
+        "current_streak",
+        "best_streak",
+        "last_activity_date",
+        "daily_goal",
+        "daily_progress",
+    }
+
+    mastery = s["mastery_summary"]
+    assert set(mastery.keys()) == {"not_started", "in_progress", "mastered", "needs_review"}
+
+    assert s["recent_sessions"] == []
+
+    week = s["last_7_days"]
+    assert set(week.keys()) == {"sessions", "attempts", "accuracy", "by_day"}
+    assert len(week["by_day"]) == 7
+    assert all(d["attempts"] == 0 for d in week["by_day"])
+
+
+@pytest.mark.django_db
+def test_overview_sorted_by_display_name(auth_client):
+    auth_client.post("/api/students/", {"display_name": "Zoé", "grade": "P1"}, format="json")
+    auth_client.post("/api/students/", {"display_name": "Ana", "grade": "P1"}, format="json")
+    auth_client.post("/api/students/", {"display_name": "Milo", "grade": "P1"}, format="json")
+
+    res = auth_client.get("/api/parent/overview/")
+    names = [s["display_name"] for s in res.json()["students"]]
+    assert names == ["Ana", "Milo", "Zoé"]
+
+
+@pytest.mark.django_db
+def test_overview_scoped_to_requesting_user(auth_client, other_user, api):
+    auth_client.post("/api/students/", {"display_name": "Mine", "grade": "P1"}, format="json")
+
+    from apps.students.models import Student
+
+    Student.objects.create(user=other_user, display_name="Theirs", grade="P3")
+
+    res = auth_client.get("/api/parent/overview/")
+    names = [s["display_name"] for s in res.json()["students"]]
+    assert names == ["Mine"]
+
+    api.force_authenticate(other_user)
+    res = api.get("/api/parent/overview/")
+    names = [s["display_name"] for s in res.json()["students"]]
+    assert names == ["Theirs"]
+
+
+@pytest.mark.django_db
+def test_overview_reflects_attempts_in_last_7_days(auth_client):
+    from apps.exercises.models import Attempt, ExerciseTemplate
+    from apps.sessions.models import Session
+    from apps.students.models import Student
+
+    student_id = auth_client.post(
+        "/api/students/", {"display_name": "Eva", "grade": "P1"}, format="json"
+    ).json()["id"]
+    student = Student.objects.get(id=student_id)
+
+    session = Session.objects.create(student=student, mode="learn")
+    template = ExerciseTemplate.objects.first()
+    Attempt.objects.create(
+        session=session,
+        skill=template.skill,
+        template=template,
+        input_type="number",
+        exercise_params={},
+        student_answer="1",
+        correct_answer="1",
+        is_correct=True,
+    )
+    Attempt.objects.create(
+        session=session,
+        skill=template.skill,
+        template=template,
+        input_type="number",
+        exercise_params={},
+        student_answer="2",
+        correct_answer="3",
+        is_correct=False,
+    )
+
+    res = auth_client.get("/api/parent/overview/")
+    s = res.json()["students"][0]
+    week = s["last_7_days"]
+    assert week["attempts"] == 2
+    assert week["accuracy"] == 0.5
+    assert week["sessions"] == 1
+
+    today = week["by_day"][-1]
+    assert today["attempts"] == 2
+    assert today["accuracy"] == 0.5
+
+
+@pytest.mark.django_db
+def test_overview_ignores_attempts_older_than_7_days(auth_client):
+    from apps.exercises.models import Attempt, ExerciseTemplate
+    from apps.sessions.models import Session
+    from apps.students.models import Student
+
+    student_id = auth_client.post(
+        "/api/students/", {"display_name": "Old", "grade": "P1"}, format="json"
+    ).json()["id"]
+    student = Student.objects.get(id=student_id)
+
+    session = Session.objects.create(student=student, mode="learn")
+    template = ExerciseTemplate.objects.first()
+    old = Attempt.objects.create(
+        session=session,
+        skill=template.skill,
+        template=template,
+        input_type="number",
+        exercise_params={},
+        student_answer="1",
+        correct_answer="1",
+        is_correct=True,
+    )
+    Attempt.objects.filter(pk=old.pk).update(responded_at=timezone.now() - timedelta(days=30))
+
+    res = auth_client.get("/api/parent/overview/")
+    week = res.json()["students"][0]["last_7_days"]
+    assert week["attempts"] == 0

--- a/frontend/e2e/parent-dashboard.spec.js
+++ b/frontend/e2e/parent-dashboard.spec.js
@@ -1,0 +1,37 @@
+import { test, expect } from "@playwright/test"
+import { mkdirSync } from "node:fs"
+
+const SHOTS = "e2e/screenshots"
+mkdirSync(SHOTS, { recursive: true })
+
+test("parent can open /dashboard and see their children", async ({ page }) => {
+  const email = `e2e-dash-${Date.now()}@example.com`
+
+  await page.goto("/register")
+  await page.getByTestId("register-name").fill("Marie")
+  await page.getByTestId("register-email").fill(email)
+  await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-submit").click()
+  await expect(page).toHaveURL(/\/children/)
+
+  await page.getByTestId("child-name").fill("Léo")
+  await page.getByTestId("child-grade").selectOption("P2")
+  await page.getByTestId("child-add").click()
+  await expect(
+    page.getByTestId("children-list").locator("[data-testid^='child-']")
+  ).toHaveCount(1)
+
+  await page.getByTestId("go-parent-dashboard").click()
+  await expect(page).toHaveURL(/\/dashboard/)
+  await expect(page.getByRole("heading", { name: /espace parent/i })).toBeVisible()
+
+  const list = page.getByTestId("parent-students-list")
+  await expect(list.locator("[data-testid^='parent-student-']")).toHaveCount(1)
+  await expect(list.getByText("Léo")).toBeVisible()
+  await expect(list.getByText(/niveau p2/i)).toBeVisible()
+
+  await page.screenshot({ path: `${SHOTS}/parent-dashboard.png`, fullPage: true })
+
+  await page.getByTestId("go-child-mode").click()
+  await expect(page).toHaveURL(/\/children/)
+})

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,6 +15,7 @@ import ProfileScreen from "./components/screens/ProfileScreen"
 import DebugInputsScreen from "./components/screens/DebugInputsScreen"
 import HistoryScreen from "./components/screens/HistoryScreen"
 import DiagnosticReviewScreen from "./components/screens/DiagnosticReviewScreen"
+import ParentDashboardScreen from "./components/screens/ParentDashboardScreen"
 import BadgeToast from "./components/badges/BadgeToast"
 import "./App.css"
 
@@ -45,6 +46,7 @@ export default function App() {
         <Route path="/register" element={<RegisterScreen />} />
         <Route path="/auth/google/callback" element={<GoogleCallbackScreen />} />
         <Route path="/children" element={<RequireAuth><ChildPickerScreen /></RequireAuth>} />
+        <Route path="/dashboard" element={<RequireAuth><ParentDashboardScreen /></RequireAuth>} />
         <Route path="/" element={<RequireAuth><WelcomeScreen /></RequireAuth>} />
         <Route path="/exercise" element={<RequireAuth><ExerciseScreen /></RequireAuth>} />
         <Route path="/diagnostic" element={<RequireAuth><DiagnosticScreen /></RequireAuth>} />

--- a/frontend/src/api/parent.js
+++ b/frontend/src/api/parent.js
@@ -1,0 +1,3 @@
+import { api } from "./client"
+
+export const fetchParentOverview = () => api.get("/parent/overview/")

--- a/frontend/src/components/screens/ChildPickerScreen.jsx
+++ b/frontend/src/components/screens/ChildPickerScreen.jsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { useNavigate } from "react-router"
+import { Link, useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -55,13 +55,22 @@ export default function ChildPickerScreen() {
             </Heading>
             <p className="text-stem mt-3">Choisis le carnet de ton jardin.</p>
           </div>
-          <button
-            onClick={logout}
-            data-testid="logout"
-            className="text-stem hover:text-bark text-sm cursor-pointer"
-          >
-            Se déconnecter
-          </button>
+          <div className="flex flex-col items-end gap-2">
+            <Link
+              to="/dashboard"
+              data-testid="go-parent-dashboard"
+              className="text-stem hover:text-bark text-sm"
+            >
+              Espace parent →
+            </Link>
+            <button
+              onClick={logout}
+              data-testid="logout"
+              className="text-stem hover:text-bark text-sm cursor-pointer"
+            >
+              Se déconnecter
+            </button>
+          </div>
         </header>
 
         <section

--- a/frontend/src/components/screens/DiagnosticReviewScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticReviewScreen.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useNavigate, useParams } from "react-router"
+import { useNavigate, useParams, useSearchParams } from "react-router"
 import { diagnosticApi } from "../../api/diagnostic"
 import { useAuthStore } from "../../stores/authStore"
 import DiagnosticResult from "./DiagnosticResult"
@@ -7,6 +7,8 @@ import DiagnosticResult from "./DiagnosticResult"
 export default function DiagnosticReviewScreen() {
   const { sessionId } = useParams()
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const fromParent = searchParams.get("from") === "parent"
   const { children, selectedChildId } = useAuthStore()
   const [result, setResult] = useState(null)
   const [error, setError] = useState(null)
@@ -50,7 +52,7 @@ export default function DiagnosticReviewScreen() {
     <DiagnosticResult
       result={result}
       child={child}
-      onBack={() => navigate("/history")}
+      onBack={() => navigate(fromParent ? "/history?from=parent" : "/history")}
       backLabel="Retour à l’historique"
       backIcon="arrow_back"
     />

--- a/frontend/src/components/screens/HistoryScreen.jsx
+++ b/frontend/src/components/screens/HistoryScreen.jsx
@@ -187,7 +187,11 @@ export default function HistoryScreen() {
               <SessionRow
                 key={row.id}
                 row={row}
-                onOpen={(r) => navigate(`/history/diagnostic/${r.id}`)}
+                onOpen={(r) =>
+                  navigate(
+                    `/history/diagnostic/${r.id}${fromParent ? "?from=parent" : ""}`
+                  )
+                }
               />
             ))}
           </Card>

--- a/frontend/src/components/screens/HistoryScreen.jsx
+++ b/frontend/src/components/screens/HistoryScreen.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react"
-import { useNavigate } from "react-router"
+import { useNavigate, useSearchParams } from "react-router"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -97,6 +97,10 @@ function SessionRow({ row, onOpen }) {
 
 export default function HistoryScreen() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const fromParent = searchParams.get("from") === "parent"
+  const backTo = fromParent ? "/dashboard" : "/"
+  const backLabel = fromParent ? "Espace parent" : "Retour"
   const { selectedChildId, children } = useAuthStore()
   const child = children.find((c) => c.id === selectedChildId)
   const [rows, setRows] = useState(null)
@@ -124,10 +128,11 @@ export default function HistoryScreen() {
     <div className="min-h-screen greenhouse flex flex-col items-center p-6">
       <div className="w-full max-w-2xl mb-4 flex justify-between items-center">
         <button
-          onClick={() => navigate("/")}
+          onClick={() => navigate(backTo)}
           className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
+          data-testid="history-back"
         >
-          <Icon name="arrow_back" size={16} /> Retour
+          <Icon name="arrow_back" size={16} /> {backLabel}
         </button>
         {child && (
           <div className="text-right">

--- a/frontend/src/components/screens/ParentDashboardScreen.jsx
+++ b/frontend/src/components/screens/ParentDashboardScreen.jsx
@@ -1,0 +1,231 @@
+import { useQuery } from "@tanstack/react-query"
+import { Link, useNavigate } from "react-router"
+import { useAuthStore } from "../../stores/authStore"
+import { fetchParentOverview } from "../../api/parent"
+import Button from "../ui/Button"
+import Card from "../ui/Card"
+import Chip from "../ui/Chip"
+import ProgressBar from "../ui/ProgressBar"
+import { Heading, LatinLabel } from "../ui/Heading"
+
+const MODE_LABELS = {
+  learn: "Entraînement",
+  diagnostic: "Diagnostic",
+  drill: "Automatismes",
+  exam: "Examen",
+}
+
+function formatDate(iso) {
+  if (!iso) return "—"
+  return new Date(iso).toLocaleDateString("fr-BE", { day: "2-digit", month: "short" })
+}
+
+function formatDuration(seconds) {
+  if (!seconds) return "—"
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  if (m === 0) return `${s}s`
+  return `${m}m${s.toString().padStart(2, "0")}`
+}
+
+function StudentCard({ student, onOpenDetail }) {
+  const m = student.mastery_summary || {}
+  const total =
+    (m.not_started || 0) + (m.in_progress || 0) + (m.mastered || 0) + (m.needs_review || 0)
+  const g = student.gamification || {}
+  const week = student.last_7_days || { sessions: 0, attempts: 0, accuracy: 0, by_day: [] }
+  const weekPct = Math.round((week.accuracy || 0) * 100)
+  const dailyGoal = g.daily_goal || 0
+  const dailyDone = g.daily_progress || 0
+
+  return (
+    <Card variant="specimen" className="p-6" data-testid={`parent-student-${student.id}`}>
+      <div className="flex items-baseline justify-between gap-4 mb-4">
+        <div>
+          <Heading level={3} className="text-sage-deep">
+            {student.display_name}
+          </Heading>
+          <LatinLabel className="block mt-1">Niveau {student.grade}</LatinLabel>
+        </div>
+        <Button variant="ghost" onClick={() => onOpenDetail(student)}>
+          Voir en détail →
+        </Button>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-3">
+        <section className="space-y-3">
+          <div className="flex items-center justify-between">
+            <LatinLabel>Hortus · Maîtrise</LatinLabel>
+            <span className="font-mono text-xs text-stem tabular-nums">
+              {m.mastered || 0} / {total}
+            </span>
+          </div>
+          <ProgressBar value={m.mastered || 0} max={Math.max(total, 1)} tone="sage" />
+          <div className="flex flex-wrap gap-1.5">
+            <Chip tone="sage">{m.mastered || 0} floraison</Chip>
+            <Chip tone="sky">{m.in_progress || 0} en croissance</Chip>
+            <Chip tone="honey">{m.needs_review || 0} à arroser</Chip>
+            <Chip tone="bark">{m.not_started || 0} en sommeil</Chip>
+          </div>
+        </section>
+
+        <section>
+          <LatinLabel>Activité récente</LatinLabel>
+          <div className="mt-2 text-sm text-stem">
+            7 derniers jours :{" "}
+            <span className="text-bark font-medium">{week.attempts}</span> exercices ·{" "}
+            <span className="text-bark font-medium">{weekPct}%</span> de réussite ·{" "}
+            {week.sessions} session{week.sessions > 1 ? "s" : ""}
+          </div>
+          <ul className="mt-3 space-y-1.5">
+            {(student.recent_sessions || []).slice(0, 5).map((s) => {
+              const pct = Math.round((s.accuracy || 0) * 100)
+              const tone =
+                pct >= 80 ? "text-sage-deep" : pct >= 40 ? "text-honey" : "text-rose"
+              return (
+                <li
+                  key={s.id}
+                  className="flex items-baseline justify-between gap-2 text-sm"
+                >
+                  <span className="text-stem truncate">
+                    {formatDate(s.started_at)} · {MODE_LABELS[s.mode] || s.mode}
+                  </span>
+                  <span className="font-mono tabular-nums text-xs flex items-center gap-2">
+                    <span className="text-stem">{formatDuration(s.duration_seconds)}</span>
+                    <span className={tone}>{pct}%</span>
+                  </span>
+                </li>
+              )
+            })}
+            {(student.recent_sessions || []).length === 0 && (
+              <li className="latin text-sm">Aucune session pour le moment.</li>
+            )}
+          </ul>
+        </section>
+
+        <section className="space-y-3">
+          <LatinLabel>Progrès</LatinLabel>
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <div>
+              <div className="font-display text-2xl text-sage-deep tabular-nums">
+                {g.xp || 0}
+              </div>
+              <div className="latin text-[10px]">XP</div>
+            </div>
+            <div>
+              <div className="font-display text-2xl text-sage-deep tabular-nums">
+                {g.current_streak || 0}
+              </div>
+              <div className="latin text-[10px]">série</div>
+            </div>
+            <div>
+              <div className="font-display text-2xl text-sage-deep tabular-nums">
+                {g.best_streak || 0}
+              </div>
+              <div className="latin text-[10px]">record</div>
+            </div>
+          </div>
+          <div>
+            <div className="flex justify-between text-xs text-stem mb-1">
+              <span>Objectif du jour</span>
+              <span className="font-mono tabular-nums">
+                {dailyDone} / {Math.max(dailyGoal, 1)}
+              </span>
+            </div>
+            <ProgressBar value={dailyDone} max={Math.max(dailyGoal, 1)} tone="honey" />
+          </div>
+          <div className="text-xs text-stem">
+            Rang :{" "}
+            <span className="text-bark font-medium capitalize">{g.rank || "—"}</span>
+          </div>
+        </section>
+      </div>
+    </Card>
+  )
+}
+
+export default function ParentDashboardScreen() {
+  const { user, logout } = useAuthStore()
+  const navigate = useNavigate()
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["parent-overview"],
+    queryFn: fetchParentOverview,
+  })
+
+  const onOpenDetail = (student) => {
+    useAuthStore.getState().selectChild(student.id)
+    navigate("/profile")
+  }
+
+  const students = data?.students || []
+
+  return (
+    <div className="min-h-screen greenhouse">
+      <div className="max-w-5xl mx-auto px-6 py-10 md:py-14">
+        <header className="flex items-start justify-between gap-4 mb-10">
+          <div>
+            <LatinLabel>Custos horti</LatinLabel>
+            <Heading level={2} className="mt-1">
+              Espace parent
+              {user?.display_name ? (
+                <>
+                  {" "}
+                  ·{" "}
+                  <em className="text-sage-deep not-italic font-display italic">
+                    {user.display_name}
+                  </em>
+                </>
+              ) : null}
+            </Heading>
+            <p className="text-stem mt-3">
+              Vue d’ensemble de chaque jardin — progrès, sessions récentes et objectifs.
+            </p>
+          </div>
+          <div className="flex flex-col items-end gap-2">
+            <Link
+              to="/children"
+              className="text-stem hover:text-bark text-sm"
+              data-testid="go-child-mode"
+            >
+              Mode enfant →
+            </Link>
+            <button
+              onClick={logout}
+              className="text-stem hover:text-bark text-sm cursor-pointer"
+              data-testid="logout"
+            >
+              Se déconnecter
+            </button>
+          </div>
+        </header>
+
+        {isLoading && <p className="latin text-center py-10">Chargement du jardin…</p>}
+        {error && (
+          <Card variant="paper" className="p-6 text-rose">
+            Impossible de charger les données ({error.message}).
+          </Card>
+        )}
+
+        {!isLoading && !error && students.length === 0 && (
+          <Card variant="tag" className="p-6">
+            <p className="latin">
+              Aucun profil pour le moment. Ajoute un carnet depuis le mode enfant.
+            </p>
+            <Button className="mt-4" onClick={() => navigate("/children")}>
+              Aller au mode enfant
+            </Button>
+          </Card>
+        )}
+
+        <div
+          className="grid gap-6 grid-cols-1"
+          data-testid="parent-students-list"
+        >
+          {students.map((s) => (
+            <StudentCard key={s.id} student={s} onOpenDetail={onOpenDetail} />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/screens/ParentDashboardScreen.jsx
+++ b/frontend/src/components/screens/ParentDashboardScreen.jsx
@@ -154,7 +154,7 @@ export default function ParentDashboardScreen() {
 
   const onOpenDetail = (student) => {
     useAuthStore.getState().selectChild(student.id)
-    navigate("/profile")
+    navigate("/history?from=parent")
   }
 
   const students = data?.students || []


### PR DESCRIPTION
Closes #96. Re-opened against main after #95 merged.

## Summary
- New `/dashboard` route rendering `ParentDashboardScreen`, consuming the overview endpoint landed in #95.
- Per-student card: mastery chips + progress, last 5 sessions + 7-day stats, gamification (XP, streaks, daily goal).
- "Voir en détail" selects the student and opens their session history (`/history?from=parent`); that flag propagates end-to-end so the back arrow returns to `/dashboard` from history + diagnostic review.
- "Espace parent →" link on the ChildPicker header.
- Playwright smoke test + lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)