### PR TITLE
feat(#99): app-layer rate limiting on /api/auth/*

### DIFF
--- a/backend/apps/accounts/views.py
+++ b/backend/apps/accounts/views.py
@@ -1,15 +1,34 @@
 from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
 from allauth.socialaccount.providers.oauth2.client import OAuth2Client
-from dj_rest_auth.registration.views import SocialLoginView
+from dj_rest_auth.registration.views import RegisterView, SocialLoginView
+from dj_rest_auth.views import LoginView, PasswordResetView
 from dj_rest_auth.views import UserDetailsView as _UserDetailsView
 from django.conf import settings
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
+from rest_framework.throttling import ScopedRateThrottle
+
+
+class ThrottledLoginView(LoginView):
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "login"
+
+
+class ThrottledRegisterView(RegisterView):
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "register"
+
+
+class ThrottledPasswordResetView(PasswordResetView):
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "password_reset"
 
 
 class GoogleLogin(SocialLoginView):
     adapter_class = GoogleOAuth2Adapter
     client_class = OAuth2Client
+    throttle_classes = [ScopedRateThrottle]
+    throttle_scope = "login"
 
     @property
     def callback_url(self):

--- a/backend/pedagogia/settings/base.py
+++ b/backend/pedagogia/settings/base.py
@@ -118,8 +118,8 @@ REST_FRAMEWORK = {
 
 CACHES = {
     "default": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "LOCATION": "pedagogia-default",
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "pedagogia_cache",
     },
 }
 

--- a/backend/pedagogia/settings/base.py
+++ b/backend/pedagogia/settings/base.py
@@ -103,6 +103,24 @@ REST_FRAMEWORK = {
         "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+        "rest_framework.throttling.UserRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "60/min",
+        "user": "300/min",
+        "login": "10/min",
+        "register": "5/hour",
+        "password_reset": "5/hour",
+    },
+}
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "pedagogia-default",
+    },
 }
 
 REST_AUTH = {

--- a/backend/pedagogia/settings/prod.py
+++ b/backend/pedagogia/settings/prod.py
@@ -36,13 +36,6 @@ X_FRAME_OPTIONS = "DENY"
 SESSION_COOKIE_SAMESITE = "Lax"
 CSRF_COOKIE_SAMESITE = "Lax"
 
-CACHES = {
-    "default": {
-        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
-        "LOCATION": "pedagogia_cache",
-    },
-}
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/backend/pedagogia/settings/prod.py
+++ b/backend/pedagogia/settings/prod.py
@@ -36,6 +36,13 @@ X_FRAME_OPTIONS = "DENY"
 SESSION_COOKIE_SAMESITE = "Lax"
 CSRF_COOKIE_SAMESITE = "Lax"
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "pedagogia_cache",
+    },
+}
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/backend/pedagogia/urls.py
+++ b/backend/pedagogia/urls.py
@@ -5,7 +5,13 @@ from django.urls import include, path
 from django.views.decorators.csrf import ensure_csrf_cookie
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
-from apps.accounts.views import GoogleLogin, UserDetailsView
+from apps.accounts.views import (
+    GoogleLogin,
+    ThrottledLoginView,
+    ThrottledPasswordResetView,
+    ThrottledRegisterView,
+    UserDetailsView,
+)
 
 
 @ensure_csrf_cookie
@@ -25,6 +31,13 @@ urlpatterns = [
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/docs/", SpectacularSwaggerView.as_view(url_name="schema")),
     path("api/auth/user/", UserDetailsView.as_view(), name="rest_user_details"),
+    path("api/auth/login/", ThrottledLoginView.as_view(), name="rest_login"),
+    path(
+        "api/auth/password/reset/",
+        ThrottledPasswordResetView.as_view(),
+        name="rest_password_reset",
+    ),
+    path("api/auth/registration/", ThrottledRegisterView.as_view(), name="rest_register"),
     path("api/auth/", include("dj_rest_auth.urls")),
     path("api/auth/registration/", include("dj_rest_auth.registration.urls")),
     path("api/auth/google/", GoogleLogin.as_view(), name="google_login"),

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -2,6 +2,7 @@
 set -e
 
 uv run python manage.py migrate --noinput
+uv run python manage.py createcachetable
 uv run python manage.py collectstatic --noinput
 uv run python manage.py seed_skills
 uv run python manage.py seed_templates

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -6,6 +6,7 @@ from rest_framework.test import APIClient
 @pytest.fixture(scope="session")
 def django_db_setup(django_db_setup, django_db_blocker):
     with django_db_blocker.unblock():
+        call_command("createcachetable")
         call_command("seed_skills")
         call_command("seed_templates")
 

--- a/backend/tests/test_throttling.py
+++ b/backend/tests/test_throttling.py
@@ -1,0 +1,54 @@
+import pytest
+from django.core.cache import cache
+from rest_framework.test import APIClient
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    cache.clear()
+    yield
+    cache.clear()
+
+
+@pytest.mark.django_db
+def test_login_throttled_after_ten_attempts(api):
+    payload = {"email": "nobody@test.com", "password": "wrong"}
+
+    for _ in range(10):
+        res = api.post("/api/auth/login/", payload, format="json")
+        assert res.status_code == 400, res.content
+
+    res = api.post("/api/auth/login/", payload, format="json")
+    assert res.status_code == 429
+    assert "Retry-After" in res.headers
+
+
+@pytest.mark.django_db
+def test_register_throttled_after_five_attempts():
+    # Each anonymous attempt uses a fresh client so the session cookie
+    # from a successful signup doesn't re-key the throttle bucket.
+    for i in range(5):
+        res = APIClient().post(
+            "/api/auth/registration/",
+            {
+                "email": f"user{i}@test.com",
+                "password1": "SuperStrong!23",
+                "password2": "SuperStrong!23",
+                "display_name": f"User{i}",
+            },
+            format="json",
+        )
+        assert res.status_code in (201, 200, 400), res.content
+
+    res = APIClient().post(
+        "/api/auth/registration/",
+        {
+            "email": "blocked@test.com",
+            "password1": "SuperStrong!23",
+            "password2": "SuperStrong!23",
+            "display_name": "Blocked",
+        },
+        format="json",
+    )
+    assert res.status_code == 429
+    assert "Retry-After" in res.headers


### PR DESCRIPTION
Closes #99.

## Summary
- DRF `AnonRateThrottle` (60/min) + `UserRateThrottle` (300/min) applied globally via `DEFAULT_THROTTLE_CLASSES`
- `ScopedRateThrottle` on login (10/min), registration (5/hour), and password reset (5/hour); also covers the Google social-login endpoint
- Postgres-backed `DatabaseCache` in prod so throttle state is shared across Gunicorn workers; `LocMemCache` in dev/tests. `createcachetable` runs in `start.sh` on every container boot (idempotent).

## Test plan
- [x] `tests/test_throttling.py` — 11th login attempt → 429 with `Retry-After`; 6th registration → 429
- [x] Full suite passes (139 tests)
- [x] `ruff check` + `ruff format` clean