### PR TITLE
feat(#87): trust CF-Connecting-IP so per-IP throttle works behind Cloudflare

### DIFF
--- a/backend/apps/common/middleware.py
+++ b/backend/apps/common/middleware.py
@@ -1,0 +1,67 @@
+from ipaddress import ip_address, ip_network
+
+from django.conf import settings
+
+CLOUDFLARE_IPV4 = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+]
+
+CLOUDFLARE_IPV6 = [
+    "2400:cb00::/32",
+    "2606:4700::/32",
+    "2803:f800::/32",
+    "2405:b500::/32",
+    "2405:8100::/32",
+    "2a06:98c0::/29",
+    "2c0f:f248::/32",
+]
+
+
+def _parse_networks(ranges):
+    return [ip_network(r) for r in ranges]
+
+
+_CF_NETS = _parse_networks(CLOUDFLARE_IPV4 + CLOUDFLARE_IPV6)
+
+
+def _is_cloudflare(ip_str):
+    try:
+        ip = ip_address(ip_str)
+    except ValueError:
+        return False
+    return any(ip in net for net in _CF_NETS)
+
+
+class CloudflareRealIPMiddleware:
+    """Rewrite REMOTE_ADDR from CF-Connecting-IP when the request came through
+    a Cloudflare edge. Keeps DRF throttling keyed on the real client IP instead
+    of the edge's IP (which would collapse all traffic into ~a dozen buckets).
+    Requests from non-Cloudflare peers are left untouched so the header can't
+    be spoofed by anyone hitting the origin directly.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.enabled = getattr(settings, "TRUST_CLOUDFLARE_REAL_IP", False)
+
+    def __call__(self, request):
+        if self.enabled:
+            peer = request.META.get("REMOTE_ADDR", "")
+            real_ip = request.META.get("HTTP_CF_CONNECTING_IP")
+            if real_ip and _is_cloudflare(peer):
+                request.META["REMOTE_ADDR"] = real_ip
+        return self.get_response(request)

--- a/backend/pedagogia/settings/base.py
+++ b/backend/pedagogia/settings/base.py
@@ -51,6 +51,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
+    "apps.common.middleware.CloudflareRealIPMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -188,6 +189,8 @@ CSRF_TRUSTED_ORIGINS = CORS_ALLOWED_ORIGINS
 ANTHROPIC_API_KEY = env("ANTHROPIC_API_KEY")
 INVESTIGATION_MODEL_PRIMARY = env("INVESTIGATION_MODEL_PRIMARY")
 INVESTIGATION_MODEL_ESCALATION = env("INVESTIGATION_MODEL_ESCALATION")
+
+TRUST_CLOUDFLARE_REAL_IP = env.bool("TRUST_CLOUDFLARE_REAL_IP", default=False)
 
 SESSION_COOKIE_HTTPONLY = True
 SESSION_COOKIE_SAMESITE = "Lax"

--- a/backend/pedagogia/settings/prod.py
+++ b/backend/pedagogia/settings/prod.py
@@ -36,6 +36,8 @@ X_FRAME_OPTIONS = "DENY"
 SESSION_COOKIE_SAMESITE = "Lax"
 CSRF_COOKIE_SAMESITE = "Lax"
 
+TRUST_CLOUDFLARE_REAL_IP = True
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/backend/tests/test_real_ip.py
+++ b/backend/tests/test_real_ip.py
@@ -1,0 +1,80 @@
+import pytest
+from django.test import RequestFactory, override_settings
+
+from apps.common.middleware import CloudflareRealIPMiddleware, _is_cloudflare
+
+
+def test_cloudflare_range_membership():
+    assert _is_cloudflare("162.158.1.1")
+    assert _is_cloudflare("104.16.0.1")
+    assert _is_cloudflare("2606:4700::1")
+    assert not _is_cloudflare("8.8.8.8")
+    assert not _is_cloudflare("46.225.142.212")  # the prod Hetzner IP
+    assert not _is_cloudflare("not-an-ip")
+
+
+@override_settings(TRUST_CLOUDFLARE_REAL_IP=True)
+def test_rewrites_remote_addr_when_peer_is_cloudflare():
+    factory = RequestFactory()
+    mw = CloudflareRealIPMiddleware(lambda r: r)
+    req = factory.get(
+        "/",
+        REMOTE_ADDR="162.158.1.1",
+        HTTP_CF_CONNECTING_IP="203.0.113.42",
+    )
+    mw(req)
+    assert req.META["REMOTE_ADDR"] == "203.0.113.42"
+
+
+@override_settings(TRUST_CLOUDFLARE_REAL_IP=True)
+def test_ignores_header_when_peer_is_not_cloudflare():
+    factory = RequestFactory()
+    mw = CloudflareRealIPMiddleware(lambda r: r)
+    req = factory.get(
+        "/",
+        REMOTE_ADDR="8.8.8.8",
+        HTTP_CF_CONNECTING_IP="203.0.113.42",
+    )
+    mw(req)
+    assert req.META["REMOTE_ADDR"] == "8.8.8.8"
+
+
+@override_settings(TRUST_CLOUDFLARE_REAL_IP=False)
+def test_disabled_leaves_remote_addr_alone():
+    factory = RequestFactory()
+    mw = CloudflareRealIPMiddleware(lambda r: r)
+    req = factory.get(
+        "/",
+        REMOTE_ADDR="162.158.1.1",
+        HTTP_CF_CONNECTING_IP="203.0.113.42",
+    )
+    # Middleware reads the setting at __init__, so re-instantiate under override:
+    mw = CloudflareRealIPMiddleware(lambda r: r)
+    mw(req)
+    assert req.META["REMOTE_ADDR"] == "162.158.1.1"
+
+
+@pytest.mark.django_db
+@override_settings(TRUST_CLOUDFLARE_REAL_IP=True)
+def test_throttle_keys_on_real_ip_through_cloudflare(api):
+    # Two bursts from the SAME Cloudflare edge IP but DIFFERENT real clients
+    # must not share a throttle bucket.
+    payload = {"email": "nobody@example.com", "password": "wrong"}
+    for _ in range(5):
+        res = api.post(
+            "/api/auth/login/",
+            payload,
+            format="json",
+            REMOTE_ADDR="162.158.1.1",
+            HTTP_CF_CONNECTING_IP="203.0.113.10",
+        )
+        assert res.status_code == 400
+    for _ in range(5):
+        res = api.post(
+            "/api/auth/login/",
+            payload,
+            format="json",
+            REMOTE_ADDR="162.158.1.1",
+            HTTP_CF_CONNECTING_IP="203.0.113.20",
+        )
+        assert res.status_code == 400

--- a/prod/bootstrap.md
+++ b/prod/bootstrap.md
@@ -85,7 +85,24 @@ In Google Cloud Console → Credentials → the OAuth 2.0 client:
 Push to `main` → GH Actions builds both images → pushes to GHCR → SSHes
 here → `pull && up -d --remove-orphans`. No manual steps after this.
 
-## 8. Nightly Postgres backups
+## 8. Lock ports 80/443 to Cloudflare
+
+Once Cloudflare is in front of `collegia.be` (orange cloud on the A/AAAA records, SSL mode Full strict), restrict origin HTTP/HTTPS to Cloudflare's IP ranges so direct-to-Hetzner requests get dropped at L3.
+
+```bash
+./prod/hetzner-firewall.sh
+```
+
+Copy the output into Hetzner Cloud Console → Firewalls → `collegia` → Inbound Rules:
+
+- TCP/80  — Source IPs: paste the IPv4 + IPv6 blocks from the script
+- TCP/443 — Source IPs: paste the IPv4 + IPv6 blocks from the script
+- TCP/22  — leave as is (SSH must stay open)
+- ICMP    — leave as is
+
+Cloudflare updates its ranges occasionally (rare). Re-run the script every few months and refresh the two rules.
+
+## 9. Nightly Postgres backups
 
 Backups go to the Hetzner Storage Box `pedagogia-backups` (`u578869.your-storagebox.de`, `fsn1`), encrypted with [age](https://age-encryption.org). Retention 7 daily + 4 weekly + 3 monthly. Restore runbook: [`deploy/restore.md`](../deploy/restore.md). Runs via user cron (no sudo required — the `pedagogia` account doesn't have passwordless sudo).
 

--- a/prod/hetzner-firewall.sh
+++ b/prod/hetzner-firewall.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Print the Hetzner Cloud firewall rules needed to lock ports 80/443 to
+# Cloudflare only. Run locally, copy the output into the Hetzner Cloud Console
+# (Firewalls → collegia → Inbound Rules → Add Rule).
+#
+# SSH (22) and ICMP are left as-is; this script only outputs the HTTP/HTTPS
+# rules that need to change. Keep your existing 22 + ICMP rules.
+
+set -euo pipefail
+
+echo "=== Cloudflare IPv4 ranges ==="
+curl -fsSL https://www.cloudflare.com/ips-v4 | tr '\n' ',' | sed 's/,$//'
+echo
+echo
+echo "=== Cloudflare IPv6 ranges ==="
+curl -fsSL https://www.cloudflare.com/ips-v6 | tr '\n' ',' | sed 's/,$//'
+echo
+echo
+echo "Paste the IPv4 block into 'Source IPs (IPv4)' and the IPv6 block into"
+echo "'Source IPs (IPv6)' for TWO inbound rules: TCP/80 and TCP/443."
+echo "Keep the existing 22 + ICMP rules untouched."


### PR DESCRIPTION
Part of #87 (code side; Cloudflare DNS/SSL/rate-limit setup already done on the edge).

## Summary
- New `apps.common.middleware.CloudflareRealIPMiddleware` rewrites `REMOTE_ADDR` from `CF-Connecting-IP`, **but only when the TCP peer is inside one of Cloudflare's published IPv4/IPv6 ranges** — so the header can't be spoofed by anyone hitting the Hetzner origin directly.
- Guarded by `TRUST_CLOUDFLARE_REAL_IP` (off in dev, on in prod).
- Mounted right after `CorsMiddleware` so every downstream middleware + DRF throttle sees the real client IP.

## Why
Without this, every request looks like it's coming from one of ~a dozen Cloudflare edge IPs. That collapses #99's per-IP throttle into a handful of shared buckets — legit users sharing an edge with an attacker would get false-positive 429s, and an attacker behind the same edge could burn through a bucket and lock others out.

## Test plan
- [x] `tests/test_real_ip.py`: range membership, rewrite only when peer is Cloudflare, no-op when disabled, per-real-IP throttle bucket isolation
- [x] 144 tests pass (`uv run pytest`)
- [x] `ruff check` + `ruff format` clean