### PR TITLE
feat(#120): shared AppShell + TopBar + mobile rendering basics

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,7 +3,11 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#f6f8f3" />
     <title>PedagogIA — apprentissage adaptatif</title>
   </head>
   <body>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -181,6 +181,131 @@
   animation: prereq-glow 1.3s ease-in-out infinite;
 }
 
+/* ============================================================
+   App layout primitives — AppShell / TopBar / Page
+   ------------------------------------------------------------
+   - AppShell owns full-viewport height + safe-area insets so
+     individual screens never reach for `min-h-screen` directly.
+   - TopBar is a 3-slot horizontal header (leading / title /
+     trailing) and stays horizontal at every viewport — the
+     trailing slot becomes icon-only below `sm`.
+   - Page is the centered content column with consistent
+     horizontal/vertical rhythm.
+   ============================================================ */
+
+.app-shell {
+  min-height: 100svh;
+  min-height: 100dvh;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell-main {
+  flex: 1 1 auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  background: rgba(246, 248, 243, 0.85);
+  backdrop-filter: saturate(140%) blur(8px);
+  -webkit-backdrop-filter: saturate(140%) blur(8px);
+  border-bottom: 1px solid rgba(43, 58, 46, 0.06);
+}
+
+.top-bar-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+  max-width: 80rem;
+  margin: 0 auto;
+  width: 100%;
+}
+
+.top-bar-leading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+.top-bar-title {
+  flex: 1 1 auto;
+  text-align: center;
+  font-family: var(--font-display);
+  font-weight: 600;
+  font-size: 15px;
+  color: var(--color-bark);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.top-bar-trailing {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.top-bar-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 8px 12px;
+  border-radius: 9999px;
+  color: var(--color-stem);
+  font-size: 14px;
+  font-weight: 500;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease;
+  text-decoration: none;
+}
+
+.top-bar-action:hover,
+.top-bar-action:active {
+  background: rgba(43, 58, 46, 0.06);
+  color: var(--color-bark);
+}
+
+.top-bar-action:focus-visible {
+  outline: 2px solid var(--color-sky-deep);
+  outline-offset: 2px;
+}
+
+.top-bar-back .top-bar-action-label {
+  font-weight: 500;
+}
+
+/* Hide labels on phones — keep icons only — for trailing utility actions.
+   The leading "back" action keeps its label since text recall matters there. */
+@media (max-width: 480px) {
+  .top-bar-trailing .top-bar-action .top-bar-action-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+}
+
 /* Pill-shaped nav link */
 .navlink {
   padding: 9px 14px;

--- a/frontend/src/components/layout/AppShell.jsx
+++ b/frontend/src/components/layout/AppShell.jsx
@@ -1,0 +1,22 @@
+const SURFACES = {
+  greenhouse: "greenhouse",
+  paper: "paper-rule",
+  grid: "paper-grid",
+  water: "water",
+  plain: "bg-chalk"
+}
+
+export default function AppShell({
+  surface = "greenhouse",
+  topBar = null,
+  children,
+  className = ""
+}) {
+  const surfaceClass = SURFACES[surface] ?? SURFACES.greenhouse
+  return (
+    <div className={`app-shell ${surfaceClass} ${className}`}>
+      {topBar}
+      <main className="app-shell-main">{children}</main>
+    </div>
+  )
+}

--- a/frontend/src/components/layout/Page.jsx
+++ b/frontend/src/components/layout/Page.jsx
@@ -1,0 +1,18 @@
+const MAX_WIDTHS = {
+  sm: "max-w-md",
+  md: "max-w-xl",
+  lg: "max-w-2xl",
+  xl: "max-w-3xl",
+  "2xl": "max-w-4xl",
+  "3xl": "max-w-5xl",
+  full: "max-w-none"
+}
+
+export default function Page({ maxWidth = "xl", className = "", children }) {
+  const widthClass = MAX_WIDTHS[maxWidth] ?? MAX_WIDTHS.xl
+  return (
+    <div className={`mx-auto px-5 py-8 sm:px-6 sm:py-10 md:py-14 w-full ${widthClass} ${className}`}>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/layout/TopBar.jsx
+++ b/frontend/src/components/layout/TopBar.jsx
@@ -1,0 +1,11 @@
+export default function TopBar({ leading = null, title = null, trailing = null, className = "" }) {
+  return (
+    <header className={`top-bar ${className}`}>
+      <div className="top-bar-inner">
+        <div className="top-bar-leading">{leading}</div>
+        {title && <div className="top-bar-title">{title}</div>}
+        <div className="top-bar-trailing">{trailing}</div>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/layout/TopBarActions.jsx
+++ b/frontend/src/components/layout/TopBarActions.jsx
@@ -1,0 +1,46 @@
+import { Link } from "react-router"
+import Icon from "../ui/Icon"
+
+export function TopBarLink({ to, icon, children, "data-testid": testId }) {
+  return (
+    <Link to={to} data-testid={testId} className="top-bar-action">
+      {icon && <Icon name={icon} size={16} />}
+      <span className="top-bar-action-label">{children}</span>
+    </Link>
+  )
+}
+
+export function TopBarButton({ onClick, icon, children, "data-testid": testId }) {
+  return (
+    <button type="button" onClick={onClick} data-testid={testId} className="top-bar-action">
+      {icon && <Icon name={icon} size={16} />}
+      <span className="top-bar-action-label">{children}</span>
+    </button>
+  )
+}
+
+export function TopBarBack({ to, onClick, label = "Retour", "data-testid": testId }) {
+  const content = (
+    <>
+      <Icon name="arrow_back" size={18} />
+      <span className="top-bar-action-label">{label}</span>
+    </>
+  )
+  if (to) {
+    return (
+      <Link to={to} data-testid={testId} className="top-bar-action top-bar-back">
+        {content}
+      </Link>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className="top-bar-action top-bar-back"
+    >
+      {content}
+    </button>
+  )
+}

--- a/frontend/src/components/screens/ChildPickerScreen.jsx
+++ b/frontend/src/components/screens/ChildPickerScreen.jsx
@@ -1,6 +1,10 @@
 import { useState } from "react"
-import { Link, useNavigate } from "react-router"
+import { useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarLink, TopBarButton } from "../layout/TopBarActions"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
@@ -41,41 +45,44 @@ export default function ChildPickerScreen() {
     navigate("/")
   }
 
+  const single = children.length === 1
   return (
-    <div className="min-h-screen greenhouse">
-      <div className="max-w-4xl mx-auto px-6 py-10 md:py-14">
-        <header className="flex items-start justify-between gap-4 mb-10">
-          <div>
-            <LatinLabel>Horti nostri</LatinLabel>
-            <Heading level={2} className="mt-1">
-              Bonjour,<br />
-              <em className="text-sage-deep not-italic font-display italic">
-                {user?.display_name || user?.email}
-              </em>
-            </Heading>
-            <p className="text-stem mt-3">Choisis le carnet de ton jardin.</p>
-          </div>
-          <div className="flex flex-col items-end gap-2">
-            <Link
-              to="/dashboard"
-              data-testid="go-parent-dashboard"
-              className="text-stem hover:text-bark text-sm"
-            >
-              Espace parent →
-            </Link>
-            <button
-              onClick={logout}
-              data-testid="logout"
-              className="text-stem hover:text-bark text-sm cursor-pointer"
-            >
-              Se déconnecter
-            </button>
-          </div>
+    <AppShell
+      surface="greenhouse"
+      topBar={
+        <TopBar
+          trailing={
+            <>
+              <TopBarLink to="/dashboard" icon="supervisor_account" data-testid="go-parent-dashboard">
+                Espace parent
+              </TopBarLink>
+              <TopBarButton onClick={logout} icon="logout" data-testid="logout">
+                Déconnexion
+              </TopBarButton>
+            </>
+          }
+        />
+      }
+    >
+      <Page maxWidth="2xl">
+        <header className="mb-10">
+          <LatinLabel>Horti nostri</LatinLabel>
+          <Heading level={2} className="mt-1 text-balance">
+            Bonjour,{" "}
+            <em className="text-sage-deep not-italic font-display italic">
+              {user?.display_name || user?.email}
+            </em>
+          </Heading>
+          <p className="text-stem mt-3">Choisis le carnet de ton jardin.</p>
         </header>
 
         <section
           data-testid="children-list"
-          className="grid gap-6 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 mb-10"
+          className={
+            single
+              ? "flex flex-wrap justify-center gap-6 mb-10"
+              : "grid gap-6 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 mb-10"
+          }
         >
           {children.map((c) => (
             <button
@@ -141,7 +148,7 @@ export default function ChildPickerScreen() {
             </div>
           </form>
         </Card>
-      </div>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/DebugInputsScreen.jsx
+++ b/frontend/src/components/screens/DebugInputsScreen.jsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react"
 import { Link } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
 import { api } from "../../api/client"
 import ExerciseCard from "../exercises/ExerciseCard"
 
@@ -33,8 +35,8 @@ export default function DebugInputsScreen() {
   }
 
   return (
-    <div className="min-h-screen bg-chalk p-6">
-      <div className="max-w-3xl mx-auto">
+    <AppShell surface="plain">
+      <Page maxWidth="xl">
         <div className="flex items-center justify-between mb-6">
           <h1 className="font-display text-3xl font-semibold text-bark">
             Debug — Types d'exercices
@@ -83,8 +85,8 @@ export default function DebugInputsScreen() {
             </section>
           ))}
         </div>
-      </div>
-    </div>
+      </Page>
+    </AppShell>
   )
 }
 

--- a/frontend/src/components/screens/DiagnosticResult.jsx
+++ b/frontend/src/components/screens/DiagnosticResult.jsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState } from "react"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -234,8 +236,9 @@ export default function DiagnosticResult({
   const contentMounted = useMounted(200)
 
   return (
-    <div className="min-h-screen greenhouse flex flex-col items-center p-6">
-      <Card className="p-6 md:p-10 max-w-2xl w-full my-8">
+    <AppShell surface="greenhouse">
+      <Page maxWidth="lg">
+      <Card className="p-6 md:p-10">
         <VerdictHero
           verdict={verdict}
           child={child}
@@ -321,6 +324,7 @@ export default function DiagnosticResult({
           )}
         </div>
       </Card>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/DiagnosticReviewScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticReviewScreen.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useParams, useSearchParams } from "react-router"
+import AppShell from "../layout/AppShell"
 import { diagnosticApi } from "../../api/diagnostic"
 import { useAuthStore } from "../../stores/authStore"
 import DiagnosticResult from "./DiagnosticResult"
@@ -35,16 +36,22 @@ export default function DiagnosticReviewScreen() {
 
   if (error) {
     return (
-      <div className="min-h-screen greenhouse flex items-center justify-center p-6">
-        <div className="text-rose px-4 py-3 rounded-lg bg-rose/15">{error}</div>
-      </div>
+      <AppShell surface="greenhouse">
+        <div className="flex-1 flex items-center justify-center p-6">
+          <div className="text-rose px-4 py-3 rounded-lg bg-rose/15" role="alert">
+            {error}
+          </div>
+        </div>
+      </AppShell>
     )
   }
   if (!result) {
     return (
-      <div className="min-h-screen greenhouse flex items-center justify-center p-6 text-stem">
-        Chargement du test de niveau…
-      </div>
+      <AppShell surface="greenhouse">
+        <div className="flex-1 flex items-center justify-center p-6 text-stem">
+          Chargement du test de niveau…
+        </div>
+      </AppShell>
     )
   }
 

--- a/frontend/src/components/screens/DiagnosticScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticScreen.jsx
@@ -1,8 +1,9 @@
 import { useEffect } from "react"
 import { useNavigate } from "react-router"
-import Icon from "../ui/Icon"
+import AppShell from "../layout/AppShell"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import ProgressBar from "../ui/ProgressBar"
-import { LatinLabel } from "../ui/Heading"
 import ExerciseCard from "../exercises/ExerciseCard"
 import LevelGauge from "../exercises/LevelGauge"
 import { useDiagnosticStore } from "../../stores/diagnosticStore"
@@ -39,64 +40,64 @@ export default function DiagnosticScreen() {
   const progress = current ? current.index + 1 : 0
   const total = current?.total ?? 0
 
+  const title = child ? `Test de Niveau · ${child.display_name}` : "Test de Niveau"
+
   return (
-    <div className="min-h-screen paper-rule flex flex-col items-center p-6">
-      <div className="w-full max-w-xl mb-4 flex justify-between items-center">
-        <button
-          onClick={handleQuit}
-          className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-        >
-          <Icon name="arrow_back" size={16} /> Quitter
-        </button>
-        {child && (
-          <div className="text-right">
-            <LatinLabel>Locus discendi</LatinLabel>
-            <div className="text-sm text-bark font-semibold">Test de Niveau · {child.display_name}</div>
-          </div>
-        )}
-      </div>
-
-      {current && (
-        <div className="w-full max-w-xl mb-4" data-testid="diagnostic-progress">
-          <ProgressBar
-            value={progress}
-            max={total}
-            tone="sage"
-            label={`Question ${progress} / ${total}`}
-            showValue
-          />
-        </div>
-      )}
-
-      {error && (
-        <div className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4" data-testid="diagnostic-error">
-          {error}
-        </div>
-      )}
-
-      <div className="relative w-full flex justify-center">
-        <div className="w-full max-w-xl">
-          <ExerciseCard
-            key={current?.exercise?.signature || "loading"}
-            exercise={current?.exercise}
-            skill={current?.skill}
-            grade={child?.grade}
-            feedback={feedback}
-            busy={loading}
-            onSubmit={submit}
-            onNext={loadNext}
-            mode="diagnostic"
-          />
-        </div>
+    <AppShell
+      surface="paper"
+      topBar={
+        <TopBar
+          leading={<TopBarBack onClick={handleQuit} label="Quitter" />}
+          title={title}
+        />
+      }
+    >
+      <div className="flex-1 flex flex-col items-center px-5 sm:px-6 py-6 sm:py-8">
         {current && (
-          <div className="hidden lg:block absolute right-6 top-2">
-            <LevelGauge
-              grade={current?.cursor?.grade || current?.skill?.grade}
-              difficulty={current?.cursor?.difficulty || current?.difficulty}
+          <div className="w-full max-w-xl mb-4" data-testid="diagnostic-progress">
+            <ProgressBar
+              value={progress}
+              max={total}
+              tone="sage"
+              label={`Question ${progress} / ${total}`}
             />
           </div>
         )}
+
+        {error && (
+          <div
+            className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4 max-w-xl w-full"
+            data-testid="diagnostic-error"
+            role="alert"
+          >
+            {error}
+          </div>
+        )}
+
+        <div className="relative w-full flex justify-center">
+          <div className="w-full max-w-xl">
+            <ExerciseCard
+              key={current?.exercise?.signature || "loading"}
+              exercise={current?.exercise}
+              skill={current?.skill}
+              grade={child?.grade}
+              feedback={feedback}
+              busy={loading}
+              onSubmit={submit}
+              onNext={loadNext}
+              mode="diagnostic"
+            />
+          </div>
+          {current && (
+            <div className="hidden lg:block absolute right-6 top-2">
+              <LevelGauge
+                grade={current?.cursor?.grade || current?.skill?.grade}
+                difficulty={current?.cursor?.difficulty || current?.difficulty}
+              />
+            </div>
+          )}
+        </div>
       </div>
-    </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/DrillScreen.jsx
+++ b/frontend/src/components/screens/DrillScreen.jsx
@@ -1,5 +1,8 @@
 import { useEffect } from "react"
 import { useNavigate } from "react-router"
+import AppShell from "../layout/AppShell"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -13,8 +16,9 @@ import { useAuthStore } from "../../stores/authStore"
 function DrillResult({ summary, bestStreak, onBack }) {
   const pct = Math.round((summary?.accuracy || 0) * 100)
   return (
-    <div className="min-h-screen water flex flex-col items-center justify-center p-6">
-      <Card className="p-8 md:p-10 max-w-md w-full text-center">
+    <AppShell surface="water">
+      <div className="flex-1 flex flex-col items-center justify-center p-5 sm:p-6">
+      <Card className="p-6 sm:p-8 md:p-10 max-w-md w-full text-center">
         <LatinLabel>Exercitatio peracta</LatinLabel>
         <Heading level={2} className="mt-1">Bravo !</Heading>
 
@@ -41,7 +45,8 @@ function DrillResult({ summary, bestStreak, onBack }) {
           <Icon name="home" /> Retour à la serre
         </Button>
       </Card>
-    </div>
+      </div>
+    </AppShell>
   )
 }
 
@@ -73,53 +78,54 @@ export default function DrillScreen() {
   const progress = current ? current.index + 1 : 0
   const total = current?.total ?? 0
 
+  const title = child ? `Automatismes · ${child.display_name}` : "Automatismes"
+
   return (
-    <div className="min-h-screen paper-rule flex flex-col items-center p-6">
-      <div className="w-full max-w-xl mb-4 flex justify-between items-center">
-        <button
-          onClick={handleQuit}
-          className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-        >
-          <Icon name="arrow_back" size={16} /> Quitter
-        </button>
-        {child && (
-          <div className="text-right">
-            <LatinLabel>Exercitatio</LatinLabel>
-            <div className="text-sm text-bark font-semibold">Automatismes · {child.display_name}</div>
+    <AppShell
+      surface="paper"
+      topBar={
+        <TopBar
+          leading={<TopBarBack onClick={handleQuit} label="Quitter" />}
+          title={title}
+        />
+      }
+    >
+      <div className="flex-1 flex flex-col items-center px-5 sm:px-6 py-6 sm:py-8">
+        {current && (
+          <div className="w-full max-w-xl mb-4" data-testid="drill-progress">
+            <div className="flex justify-between items-center mb-1.5">
+              <span className="text-xs text-stem font-mono">
+                Question {progress} / {total}
+              </span>
+              <Chip tone="honey" className="!text-[10px]">
+                <Icon name="bolt" size={12} fill /> {streak} · best {bestStreak}
+              </Chip>
+            </div>
+            <ProgressBar value={progress} max={total} tone="sage" />
           </div>
         )}
-      </div>
 
-      {current && (
-        <div className="w-full max-w-xl mb-4" data-testid="drill-progress">
-          <div className="flex justify-between items-center mb-1.5">
-            <span className="text-xs text-stem font-mono">
-              Question {progress} / {total}
-            </span>
-            <Chip tone="honey" className="!text-[10px]">
-              <Icon name="bolt" size={12} fill /> {streak} · best {bestStreak}
-            </Chip>
+        {error && (
+          <div
+            className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4 max-w-xl w-full"
+            data-testid="drill-error"
+            role="alert"
+          >
+            {error}
           </div>
-          <ProgressBar value={progress} max={total} tone="sage" />
-        </div>
-      )}
+        )}
 
-      {error && (
-        <div className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4" data-testid="drill-error">
-          {error}
-        </div>
-      )}
-
-      <ExerciseCard
-        key={current?.exercise?.signature || "loading"}
-        exercise={current?.exercise}
-        skill={current?.skill}
-        grade={child?.grade}
-        feedback={feedback}
-        busy={loading}
-        onSubmit={submit}
-        onNext={loadNext}
-      />
-    </div>
+        <ExerciseCard
+          key={current?.exercise?.signature || "loading"}
+          exercise={current?.exercise}
+          skill={current?.skill}
+          grade={child?.grade}
+          feedback={feedback}
+          busy={loading}
+          onSubmit={submit}
+          onNext={loadNext}
+        />
+      </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/ExamScreen.jsx
+++ b/frontend/src/components/screens/ExamScreen.jsx
@@ -1,5 +1,8 @@
 import { useEffect } from "react"
 import { useNavigate } from "react-router"
+import AppShell from "../layout/AppShell"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -13,8 +16,9 @@ function ExamResult({ summary, onBack }) {
   const pct = Math.round((summary?.accuracy || 0) * 100)
   const breakdown = summary?.breakdown || []
   return (
-    <div className="min-h-screen water flex flex-col items-center justify-center p-6">
-      <Card className="p-8 md:p-10 max-w-lg w-full">
+    <AppShell surface="water">
+      <div className="flex-1 flex flex-col items-center justify-center p-5 sm:p-6">
+      <Card className="p-6 sm:p-8 md:p-10 max-w-lg w-full">
         <div className="text-center">
           <LatinLabel>Examinatio peracta</LatinLabel>
           <Heading level={2} className="mt-1">Résultat</Heading>
@@ -63,7 +67,8 @@ function ExamResult({ summary, onBack }) {
           <Icon name="home" /> Retour à la serre
         </Button>
       </Card>
-    </div>
+      </div>
+    </AppShell>
   )
 }
 
@@ -95,51 +100,52 @@ export default function ExamScreen() {
   const progress = current ? current.index + 1 : 0
   const total = current?.total ?? 0
 
+  const title = child ? `Examen · ${child.display_name}` : "Examen"
+
   return (
-    <div className="min-h-screen paper-rule flex flex-col items-center p-6">
-      <div className="w-full max-w-xl mb-4 flex justify-between items-center">
-        <button
-          onClick={handleQuit}
-          className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-        >
-          <Icon name="arrow_back" size={16} /> Quitter
-        </button>
-        {child && (
-          <div className="text-right">
-            <LatinLabel>Examinatio</LatinLabel>
-            <div className="text-sm text-bark font-semibold">Examen · {child.display_name}</div>
+    <AppShell
+      surface="paper"
+      topBar={
+        <TopBar
+          leading={<TopBarBack onClick={handleQuit} label="Quitter" />}
+          title={title}
+        />
+      }
+    >
+      <div className="flex-1 flex flex-col items-center px-5 sm:px-6 py-6 sm:py-8">
+        {current && (
+          <div className="w-full max-w-xl mb-4" data-testid="exam-progress">
+            <div className="flex justify-between items-center mb-1.5">
+              <span className="text-xs text-stem font-mono">
+                Question {progress} / {total}
+              </span>
+            </div>
+            <ProgressBar value={progress} max={total} tone="sage" />
           </div>
         )}
-      </div>
 
-      {current && (
-        <div className="w-full max-w-xl mb-4" data-testid="exam-progress">
-          <div className="flex justify-between items-center mb-1.5">
-            <span className="text-xs text-stem font-mono">
-              Question {progress} / {total}
-            </span>
+        {error && (
+          <div
+            className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4 max-w-xl w-full"
+            data-testid="exam-error"
+            role="alert"
+          >
+            {error}
           </div>
-          <ProgressBar value={progress} max={total} tone="sage" />
-        </div>
-      )}
+        )}
 
-      {error && (
-        <div className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4" data-testid="exam-error">
-          {error}
-        </div>
-      )}
-
-      <ExerciseCard
-        key={current?.exercise?.signature || "loading"}
-        exercise={current?.exercise}
-        skill={current?.skill}
-        grade={child?.grade}
-        feedback={feedback}
-        busy={loading}
-        onSubmit={submit}
-        onNext={loadNext}
-        mode="exam"
-      />
-    </div>
+        <ExerciseCard
+          key={current?.exercise?.signature || "loading"}
+          exercise={current?.exercise}
+          skill={current?.skill}
+          grade={child?.grade}
+          feedback={feedback}
+          busy={loading}
+          onSubmit={submit}
+          onNext={loadNext}
+          mode="exam"
+        />
+      </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/ExerciseScreen.jsx
+++ b/frontend/src/components/screens/ExerciseScreen.jsx
@@ -1,7 +1,8 @@
 import { useEffect } from "react"
 import { useNavigate, useSearchParams } from "react-router"
-import Icon from "../ui/Icon"
-import { LatinLabel } from "../ui/Heading"
+import AppShell from "../layout/AppShell"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import ExerciseCard from "../exercises/ExerciseCard"
 import { useSessionStore } from "../../stores/sessionStore"
 import { useAuthStore } from "../../stores/authStore"
@@ -32,47 +33,44 @@ export default function ExerciseScreen() {
     navigate("/")
   }
 
+  const sessionLabel = lockedSkillId ? "Séance libre" : "Établi"
+  const title = child ? `${sessionLabel} · ${child.display_name}` : sessionLabel
+
   return (
-    <div className="min-h-screen paper-rule flex flex-col items-center p-6">
-      <div className="w-full max-w-xl mb-6 flex justify-between items-center">
-        <button
-          onClick={handleStop}
-          className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-        >
-          <Icon name="arrow_back" size={16} /> Arrêter
-        </button>
-        {child && (
-          <div className="text-right">
-            <LatinLabel>In officina</LatinLabel>
-            <div className="text-sm text-bark font-semibold">
-              {lockedSkillId ? "Séance libre" : "Établi"} · {child.display_name}
-            </div>
+    <AppShell
+      surface="paper"
+      topBar={
+        <TopBar
+          leading={<TopBarBack onClick={handleStop} label="Arrêter" />}
+          title={title}
+        />
+      }
+    >
+      <div className="flex-1 flex flex-col items-center px-5 sm:px-6 py-6 sm:py-8">
+        {error && (
+          <div
+            className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4 max-w-xl w-full"
+            data-testid="exercise-error"
+            role="alert"
+          >
+            {error}
           </div>
         )}
+
+        <ExerciseCard
+          key={current?.exercise?.signature || "loading"}
+          exercise={current?.exercise}
+          skill={current?.skill}
+          grade={child?.grade}
+          feedback={feedback}
+          explanation={explanation}
+          explaining={explaining}
+          onExplain={explain}
+          busy={loading}
+          onSubmit={submit}
+          onNext={loadNext}
+        />
       </div>
-
-      {error && (
-        <div
-          className="text-rose px-3 py-2 rounded-lg bg-rose-soft/60 mb-4"
-          data-testid="exercise-error"
-        >
-          {error}
-        </div>
-      )}
-
-      <ExerciseCard
-        key={current?.exercise?.signature || "loading"}
-        exercise={current?.exercise}
-        skill={current?.skill}
-        grade={child?.grade}
-        feedback={feedback}
-        explanation={explanation}
-        explaining={explaining}
-        onExplain={explain}
-        busy={loading}
-        onSubmit={submit}
-        onNext={loadNext}
-      />
-    </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/GoogleCallbackScreen.jsx
+++ b/frontend/src/components/screens/GoogleCallbackScreen.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
+import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import { Heading, LatinLabel } from "../ui/Heading"
@@ -28,8 +29,9 @@ export default function GoogleCallbackScreen() {
   }, [code, initialError, googleLogin, navigate])
 
   return (
-    <div className="min-h-screen water flex items-center justify-center p-6">
-      <Card variant="specimen" className="p-8 text-center max-w-md space-y-5">
+    <AppShell surface="water">
+      <div className="flex-1 flex items-center justify-center p-5 sm:p-6">
+      <Card variant="specimen" className="p-6 sm:p-8 text-center max-w-md w-full space-y-5">
         {error ? (
           <>
             <LatinLabel>Iter interruptum</LatinLabel>
@@ -50,6 +52,7 @@ export default function GoogleCallbackScreen() {
           </>
         )}
       </Card>
-    </div>
+      </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/HistoryScreen.jsx
+++ b/frontend/src/components/screens/HistoryScreen.jsx
@@ -1,9 +1,13 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useSearchParams } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import { useAuthStore } from "../../stores/authStore"
 import {
   fetchSessionSummaries,
@@ -129,47 +133,43 @@ export default function HistoryScreen() {
     }
   }, [selectedChildId, navigate])
 
-  return (
-    <div className="min-h-screen greenhouse flex flex-col items-center p-6">
-      <div className="w-full max-w-2xl mb-4 flex justify-between items-center">
-        <button
-          onClick={() => navigate(backTo)}
-          className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-          data-testid="history-back"
-        >
-          <Icon name="arrow_back" size={16} /> {backLabel}
-        </button>
-        {child && (
-          <div className="text-right">
-            <LatinLabel>Memoria</LatinLabel>
-            <div className="text-sm text-bark font-semibold">
-              Historique · {child.display_name}
-            </div>
-          </div>
-        )}
-      </div>
+  const title = child ? `Historique · ${child.display_name}` : "Historique"
+  const hasRows = rows && rows.length > 0
 
-      <Card className="p-6 md:p-8 max-w-2xl w-full my-4">
+  return (
+    <AppShell
+      surface="greenhouse"
+      topBar={
+        <TopBar
+          leading={<TopBarBack to={backTo} label={backLabel} data-testid="history-back" />}
+          title={title}
+        />
+      }
+    >
+      <Page maxWidth="lg">
+        <Card className="p-6 md:p-8">
         <Heading level={2}>Historique des sessions</Heading>
 
-        <div className="flex gap-2 my-5" data-testid="history-exports">
-          <Button
-            variant="outline"
-            onClick={() => downloadStudentExport(selectedChildId, "pdf")}
-            disabled={!selectedChildId}
-            data-testid="export-pdf"
-          >
-            <Icon name="download" /> Exporter PDF
-          </Button>
-          <Button
-            variant="outline"
-            onClick={() => downloadStudentExport(selectedChildId, "json")}
-            disabled={!selectedChildId}
-            data-testid="export-json"
-          >
-            <Icon name="download" /> Exporter JSON
-          </Button>
-        </div>
+        {hasRows && (
+          <div className="flex flex-wrap gap-2 my-5" data-testid="history-exports">
+            <Button
+              variant="outline"
+              onClick={() => downloadStudentExport(selectedChildId, "pdf")}
+              disabled={!selectedChildId}
+              data-testid="export-pdf"
+            >
+              <Icon name="download" /> Exporter PDF
+            </Button>
+            <Button
+              variant="outline"
+              onClick={() => downloadStudentExport(selectedChildId, "json")}
+              disabled={!selectedChildId}
+              data-testid="export-json"
+            >
+              <Icon name="download" /> Exporter JSON
+            </Button>
+          </div>
+        )}
 
         {error && (
           <div className="text-rose px-3 py-2 rounded-lg bg-rose/15 mb-4">{error}</div>
@@ -207,6 +207,7 @@ export default function HistoryScreen() {
           </Card>
         )}
       </Card>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/LoginScreen.jsx
+++ b/frontend/src/components/screens/LoginScreen.jsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { Link, useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
 import { startGoogleLogin } from "../../lib/googleOAuth"
+import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
@@ -30,46 +31,55 @@ export default function LoginScreen() {
   }
 
   return (
-    <div className="min-h-screen greenhouse flex items-center justify-center p-6">
-      <Card variant="tag" className="w-full max-w-md p-8 space-y-5">
-        <form onSubmit={onSubmit} data-testid="login-form" className="space-y-5">
-          <div>
-            <LatinLabel>Ad hortum redi</LatinLabel>
-            <Heading level={2} className="mt-1">
-              Connexion
-            </Heading>
-            <p className="text-sm text-stem mt-1">PedagogIA — retourner au jardin.</p>
-          </div>
+    <AppShell surface="greenhouse" className="items-center justify-center">
+      <div className="flex-1 flex items-center justify-center p-5 sm:p-6">
+        <Card variant="tag" className="w-full max-w-md p-6 sm:p-8 space-y-5">
+          <form onSubmit={onSubmit} data-testid="login-form" className="space-y-5">
+            <div>
+              <LatinLabel>Ad hortum redi</LatinLabel>
+              <Heading level={2} className="mt-1">
+                Connexion
+              </Heading>
+              <p className="text-sm text-stem mt-1">PedagogIA — retourner au jardin.</p>
+            </div>
 
-          <label className="block">
-            <span className="text-sm font-medium text-bark">Email</span>
-            <Input
-              type="email"
-              required
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="mt-1"
-              data-testid="login-email"
-            />
-          </label>
+            <label className="block">
+              <span className="text-sm font-medium text-bark">Email</span>
+              <Input
+                type="email"
+                required
+                autoComplete="email"
+                inputMode="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="mt-1"
+                data-testid="login-email"
+              />
+            </label>
 
-          <label className="block">
-            <span className="text-sm font-medium text-bark">Mot de passe</span>
-            <Input
-              type="password"
-              required
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="mt-1"
-              data-testid="login-password"
-            />
-          </label>
+            <label className="block">
+              <span className="text-sm font-medium text-bark">Mot de passe</span>
+              <Input
+                type="password"
+                required
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="mt-1"
+                data-testid="login-password"
+              />
+            </label>
 
-          {error && (
-            <p className="text-sm text-rose px-3 py-2 rounded-lg bg-rose-soft/60" data-testid="login-error">
-              {error}
-            </p>
-          )}
+            {error && (
+              <p
+                className="text-sm text-rose px-3 py-2 rounded-lg bg-rose-soft/60"
+                data-testid="login-error"
+                role="alert"
+                aria-live="polite"
+              >
+                {error}
+              </p>
+            )}
 
           <Button type="submit" disabled={busy} className="w-full" data-testid="login-submit">
             {busy ? "Connexion…" : "Se connecter"}
@@ -97,14 +107,15 @@ export default function LoginScreen() {
             Se connecter avec Google
           </Button>
 
-          <p className="text-sm text-center text-stem">
-            Pas de compte ?{" "}
-            <Link to="/register" className="text-sage-deep font-semibold hover:underline">
-              Créer un compte
-            </Link>
-          </p>
-        </form>
-      </Card>
-    </div>
+            <p className="text-sm text-center text-stem">
+              Pas de compte ?{" "}
+              <Link to="/register" className="text-sage-deep font-semibold hover:underline">
+                Créer un compte
+              </Link>
+            </p>
+          </form>
+        </Card>
+      </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/ParentDashboardScreen.jsx
+++ b/frontend/src/components/screens/ParentDashboardScreen.jsx
@@ -1,7 +1,11 @@
 import { useQuery } from "@tanstack/react-query"
-import { Link, useNavigate } from "react-router"
+import { useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
 import { fetchParentOverview } from "../../api/parent"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarLink, TopBarButton } from "../layout/TopBarActions"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
@@ -160,43 +164,41 @@ export default function ParentDashboardScreen() {
   const students = data?.students || []
 
   return (
-    <div className="min-h-screen greenhouse">
-      <div className="max-w-5xl mx-auto px-6 py-10 md:py-14">
-        <header className="flex items-start justify-between gap-4 mb-10">
-          <div>
-            <LatinLabel>Custos horti</LatinLabel>
-            <Heading level={2} className="mt-1">
-              Espace parent
-              {user?.display_name ? (
-                <>
-                  {" "}
-                  ·{" "}
-                  <em className="text-sage-deep not-italic font-display italic">
-                    {user.display_name}
-                  </em>
-                </>
-              ) : null}
-            </Heading>
-            <p className="text-stem mt-3">
-              Vue d’ensemble de chaque jardin — progrès, sessions récentes et objectifs.
-            </p>
-          </div>
-          <div className="flex flex-col items-end gap-2">
-            <Link
-              to="/children"
-              className="text-stem hover:text-bark text-sm"
-              data-testid="go-child-mode"
-            >
-              Mode enfant →
-            </Link>
-            <button
-              onClick={logout}
-              className="text-stem hover:text-bark text-sm cursor-pointer"
-              data-testid="logout"
-            >
-              Se déconnecter
-            </button>
-          </div>
+    <AppShell
+      surface="greenhouse"
+      topBar={
+        <TopBar
+          trailing={
+            <>
+              <TopBarLink to="/children" icon="child_care" data-testid="go-child-mode">
+                Mode enfant
+              </TopBarLink>
+              <TopBarButton onClick={logout} icon="logout" data-testid="logout">
+                Déconnexion
+              </TopBarButton>
+            </>
+          }
+        />
+      }
+    >
+      <Page maxWidth="3xl">
+        <header className="mb-10">
+          <LatinLabel>Custos horti</LatinLabel>
+          <Heading level={2} className="mt-1 text-balance">
+            Espace parent
+            {user?.display_name ? (
+              <>
+                {" "}
+                ·{" "}
+                <em className="text-sage-deep not-italic font-display italic">
+                  {user.display_name}
+                </em>
+              </>
+            ) : null}
+          </Heading>
+          <p className="text-stem mt-3">
+            Vue d’ensemble de chaque jardin — progrès, sessions récentes et objectifs.
+          </p>
         </header>
 
         {isLoading && <p className="latin text-center py-10">Chargement du jardin…</p>}
@@ -225,7 +227,7 @@ export default function ParentDashboardScreen() {
             <StudentCard key={s.id} student={s} onOpenDetail={onOpenDetail} />
           ))}
         </div>
-      </div>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/ProfileScreen.jsx
+++ b/frontend/src/components/screens/ProfileScreen.jsx
@@ -1,5 +1,8 @@
 import { useNavigate } from "react-router"
-import Icon from "../ui/Icon"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import Card from "../ui/Card"
 import { Heading, LatinLabel } from "../ui/Heading"
 import { useAuthStore } from "../../stores/authStore"
@@ -20,15 +23,17 @@ export default function ProfileScreen() {
   }
 
   return (
-    <div className="min-h-screen bg-chalk p-6">
-      <div className="max-w-2xl mx-auto space-y-6">
-        <div className="flex justify-between items-center">
-          <button
-            onClick={() => navigate("/")}
-            className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-          >
-            <Icon name="arrow_back" size={16} /> Serre
-          </button>
+    <AppShell
+      surface="plain"
+      topBar={
+        <TopBar
+          leading={<TopBarBack to="/" label="Serre" />}
+          title="Profil"
+        />
+      }
+    >
+      <Page maxWidth="lg" className="space-y-6">
+        <div className="flex justify-end">
           <LatinLabel>Florilegium</LatinLabel>
         </div>
 
@@ -67,7 +72,7 @@ export default function ProfileScreen() {
           </div>
           <BadgeGallery earned={child.achievements || []} />
         </Card>
-      </div>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/RegisterScreen.jsx
+++ b/frontend/src/components/screens/RegisterScreen.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react"
 import { Link, useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
+import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
@@ -31,8 +32,9 @@ export default function RegisterScreen() {
   }
 
   return (
-    <div className="min-h-screen greenhouse flex items-center justify-center p-6">
-      <Card variant="tag" className="w-full max-w-md p-8 space-y-5">
+    <AppShell surface="greenhouse">
+      <div className="flex-1 flex items-center justify-center p-5 sm:p-6">
+      <Card variant="tag" className="w-full max-w-md p-6 sm:p-8 space-y-5">
         <form onSubmit={onSubmit} data-testid="register-form" className="space-y-5">
           <div>
             <LatinLabel>Novum hortum plantare</LatinLabel>
@@ -47,6 +49,7 @@ export default function RegisterScreen() {
             <Input
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
+              autoComplete="given-name"
               className="mt-1"
               data-testid="register-name"
             />
@@ -57,6 +60,8 @@ export default function RegisterScreen() {
             <Input
               type="email"
               required
+              autoComplete="email"
+              inputMode="email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               className="mt-1"
@@ -70,6 +75,7 @@ export default function RegisterScreen() {
               type="password"
               required
               minLength={8}
+              autoComplete="new-password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="mt-1"
@@ -81,6 +87,8 @@ export default function RegisterScreen() {
             <p
               className="text-sm text-rose whitespace-pre-wrap px-3 py-2 rounded-lg bg-rose-soft/60"
               data-testid="register-error"
+              role="alert"
+              aria-live="polite"
             >
               {error}
             </p>
@@ -98,6 +106,7 @@ export default function RegisterScreen() {
           </p>
         </form>
       </Card>
-    </div>
+      </div>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/SessionReviewScreen.jsx
+++ b/frontend/src/components/screens/SessionReviewScreen.jsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useState } from "react"
-import { Link, useNavigate, useParams, useSearchParams } from "react-router"
+import { Link, useParams, useSearchParams } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import Icon from "../ui/Icon"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
@@ -130,7 +134,6 @@ function AttemptRow({ attempt, index }) {
 
 export default function SessionReviewScreen() {
   const { sessionId } = useParams()
-  const navigate = useNavigate()
   const [searchParams] = useSearchParams()
   const fromParent = searchParams.get("from") === "parent"
   const { children, selectedChildId } = useAuthStore()
@@ -183,39 +186,46 @@ export default function SessionReviewScreen() {
 
   if (error) {
     return (
-      <div className="min-h-screen greenhouse flex items-center justify-center p-6">
-        <div className="text-rose px-4 py-3 rounded-lg bg-rose/15">{error}</div>
-      </div>
+      <AppShell surface="greenhouse">
+        <div className="flex-1 flex items-center justify-center p-6">
+          <div className="text-rose px-4 py-3 rounded-lg bg-rose/15" role="alert">
+            {error}
+          </div>
+        </div>
+      </AppShell>
     )
   }
 
   if (!session || !attempts) {
     return (
-      <div className="min-h-screen greenhouse flex items-center justify-center p-6 text-stem">
-        Chargement de la session…
-      </div>
+      <AppShell surface="greenhouse">
+        <div className="flex-1 flex items-center justify-center p-6 text-stem">
+          Chargement de la session…
+        </div>
+      </AppShell>
     )
   }
 
-  return (
-    <div className="min-h-screen greenhouse flex flex-col items-center p-6">
-      <div className="w-full max-w-3xl mb-4 flex justify-between items-center">
-        <button
-          onClick={() => navigate(backTo)}
-          className="text-stem hover:text-bark flex items-center gap-1.5 cursor-pointer text-sm"
-          data-testid="session-review-back"
-        >
-          <Icon name="arrow_back" size={16} /> Retour à l’historique
-        </button>
-        {child && (
-          <div className="text-right">
-            <LatinLabel>Memoria</LatinLabel>
-            <div className="text-sm text-bark font-semibold">{child.display_name}</div>
-          </div>
-        )}
-      </div>
+  const title = child ? `Session · ${child.display_name}` : "Session"
 
-      <Card className="p-6 md:p-8 max-w-3xl w-full my-2">
+  return (
+    <AppShell
+      surface="greenhouse"
+      topBar={
+        <TopBar
+          leading={
+            <TopBarBack
+              to={backTo}
+              label="Historique"
+              data-testid="session-review-back"
+            />
+          }
+          title={title}
+        />
+      }
+    >
+      <Page maxWidth="xl">
+        <Card className="p-6 md:p-8">
         <div className="flex items-baseline justify-between gap-3 mb-5">
           <div>
             <LatinLabel>Sessio</LatinLabel>
@@ -281,6 +291,7 @@ export default function SessionReviewScreen() {
           </div>
         )}
       </Card>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -15,6 +15,7 @@ import { useQuery } from "@tanstack/react-query"
 import { api } from "../../api/client"
 import { useAuthStore } from "../../stores/authStore"
 import { useSkillTree } from "../../hooks/useSkillTree"
+import AppShell from "../layout/AppShell"
 import SkillNode from "../ui/SkillNode"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -235,14 +236,16 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
 
   if (isLoading) {
     return (
-      <div className="h-screen w-screen flex items-center justify-center bg-chalk text-stem">
-        <span className="latin">Germinatio…</span>
-      </div>
+      <AppShell surface="plain">
+        <div className="flex-1 flex items-center justify-center text-stem">
+          <span className="latin">Germinatio…</span>
+        </div>
+      </AppShell>
     )
   }
 
   return (
-    <div className="h-screen w-screen flex flex-col bg-chalk">
+    <AppShell surface="plain" className="overflow-hidden">
       <header className="flex items-center gap-3 px-4 md:px-6 py-3 border-b border-sage/10 bg-paper">
         <a href="/" className="text-sage-deep hover:underline text-sm font-semibold shrink-0">
           ← Serre
@@ -351,7 +354,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
         )}
         <StatusLegend />
       </div>
-    </div>
+    </AppShell>
   )
 }
 

--- a/frontend/src/components/screens/WelcomeScreen.jsx
+++ b/frontend/src/components/screens/WelcomeScreen.jsx
@@ -5,6 +5,10 @@ import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
 import { Heading, LatinLabel } from "../ui/Heading"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarButton } from "../layout/TopBarActions"
 import { useAuthStore } from "../../stores/authStore"
 import RankChip from "../xp/RankChip"
 import XPBar from "../xp/XPBar"
@@ -55,31 +59,35 @@ export default function WelcomeScreen() {
 
   if (!child) return null
 
+  const handleLogout = async () => {
+    await logout()
+    navigate("/login")
+  }
+
   return (
-    <div className="min-h-screen greenhouse">
-      <div className="max-w-3xl mx-auto px-6 py-10 md:py-14">
-        <header className="flex items-start justify-between gap-4 mb-8">
-          <div>
-            <LatinLabel>Hortus mathematicus</LatinLabel>
-            <Heading level={1} className="mt-1">
-              Bienvenue dans ta serre,<br />
-              <em className="text-sage-deep not-italic font-display italic">
-                {child.display_name}
-              </em>
-              .
-            </Heading>
-            <p className="text-stem mt-3">Niveau {child.grade}</p>
-          </div>
-          <button
-            data-testid="logout"
-            onClick={async () => {
-              await logout()
-              navigate("/login")
-            }}
-            className="text-stem hover:text-bark text-sm flex items-center gap-1 cursor-pointer"
-          >
-            <Icon name="logout" size={16} /> Déconnexion
-          </button>
+    <AppShell
+      surface="greenhouse"
+      topBar={
+        <TopBar
+          trailing={
+            <TopBarButton onClick={handleLogout} icon="logout" data-testid="logout">
+              Déconnexion
+            </TopBarButton>
+          }
+        />
+      }
+    >
+      <Page maxWidth="xl">
+        <header className="mb-8">
+          <LatinLabel>Hortus mathematicus</LatinLabel>
+          <Heading level={1} className="mt-1 text-balance">
+            Bienvenue dans ta serre,{" "}
+            <em className="text-sage-deep not-italic font-display italic">
+              {child.display_name}
+            </em>
+            .
+          </Heading>
+          <p className="text-stem mt-3">Niveau {child.grade}</p>
         </header>
 
         <Card className="p-5 md:p-6 mb-6 space-y-4" data-testid="gamification-header">
@@ -172,7 +180,7 @@ export default function WelcomeScreen() {
             Changer de carnet
           </button>
         </div>
-      </div>
-    </div>
+      </Page>
+    </AppShell>
   )
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -58,6 +58,14 @@ html {
   scroll-behavior: smooth;
 }
 
+/* Prevent iOS Safari from auto-zooming on focus — anything < 16px triggers it.
+   We bump the baseline on phones; Tailwind utilities can still scale up. */
+input,
+select,
+textarea {
+  font-size: 16px;
+}
+
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,


### PR DESCRIPTION
## Summary
- Introduces `<AppShell>` + `<TopBar>` + `<Page>` + `<TopBarActions>` in `frontend/src/components/layout/` and migrates all 11 screens off bespoke `min-h-screen` headers. Same shell now owns safe-area insets (`env(safe-area-inset-*)` + `viewport-fit=cover`), so future iPhone notch / Android home-indicator handling is one place to fix.
- Bumps form `<input>` baseline to 16 px (suppresses iOS Safari focus-zoom). Login + Register pick up `autocomplete` / `inputmode` so password managers and the email keyboard kick in.
- In-passing fixes from the audit: top-right header stacking bug on `/children` and `/dashboard` is gone (icons collapse to icon-only below 480 px), single child centers on `/children`, Welcome title wraps to 2 lines on iPhone SE via `text-balance`, `Exporter PDF/JSON` on `/history` is hidden when there are zero sessions, duplicate `1/25` counter on `/diagnostic` removed.
- SkillTree gets wrapped in AppShell so safe-area applies, but keeps its own grade-button + search header — the touch overhaul is #121.

Closes #120.

## Test plan
- [ ] `npm run lint` clean (CI)
- [ ] `npm run build` clean (CI)
- [ ] Open http://localhost:5173 on iPhone SE viewport (375×667) — no header item clipped or vertically stacked on `/children`, `/dashboard`, `/`, `/exercise`, `/history`
- [ ] Resize between 320 → 1440 px — no horizontal scroll on any authed screen
- [ ] Focus an email/password input on a real iOS Safari (or DevTools iPhone simulation) — no zoom-on-focus
- [ ] On `/login`, password manager (1Password / Apple Keychain) offers to autofill
- [ ] Hard-refresh on a notched iPhone if available — header doesn't sit under the status bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)