### PR TITLE
fix: run deploy smoke check on the server, not the GH runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,13 +80,13 @@ jobs:
             docker compose -f docker-compose.prod.yml pull
             docker compose -f docker-compose.prod.yml up -d --remove-orphans
             docker image prune -f
-
-      - name: Smoke check
-        run: |
-          for i in 1 2 3 4 5 6 7 8 9 10; do
-            if curl -fsS "https://${{ secrets.DOMAIN }}/api/health/" >/dev/null; then
-              echo "Health check OK"; exit 0
-            fi
-            echo "Waiting for health ($i/10)..."; sleep 5
-          done
-          echo "Health check failed"; exit 1
+            for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15; do
+              status=$(docker compose -f docker-compose.prod.yml ps backend --format '{{.Health}}')
+              if [ "$status" = "healthy" ]; then
+                echo "Backend healthy"; exit 0
+              fi
+              echo "Waiting for backend health ($i/15, status=$status)..."; sleep 5
+            done
+            echo "Backend failed to become healthy"
+            docker compose -f docker-compose.prod.yml logs --tail 50 backend
+            exit 1


### PR DESCRIPTION
## Summary
Cloudflare's bot protection started 403ing requests from GitHub Actions runner IPs once the WAF rules from #87 landed, so the post-deploy `curl https://collegia.be/api/health/` always failed even when prod was fine (see [run 24602822624](https://github.com/YassineBenYaghlane/PedagogIA/actions/runs/24602822624)).

Move the smoke check inside the SSH session and poll the backend container's built-in healthcheck state. No external network hop, no Cloudflare in the way. Dumps `docker compose logs backend --tail 50` on failure so we can debug without re-SSHing.

## Test plan
- [ ] Merge → watch the deploy workflow → it reports "Backend healthy" and exits green