### PR TITLE
docs: README + wiki ingest of frontend audit + product-features snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,154 @@
-# React + Vite
+# PedagogIA
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+French-language adaptive math learning for Belgian FWB students (P1–P6). A parent account owns one or more student profiles; each student learns through diagnostic, drill, and free-practice modes, backed by a skill-tree DAG and AI-driven investigation of wrong answers.
 
-Currently, two official plugins are available:
+- Live: <https://collegia.be>
+- Project conventions: [`CLAUDE.md`](CLAUDE.md)
+- Runtime & deploy architecture: [`docs/architecture.md`](docs/architecture.md)
+- Production ops: [`prod/bootstrap.md`](prod/bootstrap.md)
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Quickstart
 
-## React Compiler
+```bash
+docker compose up -d          # Postgres + Django + Vite
+open http://localhost:5173
+```
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+Backend on `:8000` (Django + DRF), frontend on `:5173` (Vite), Postgres on `:5411`. API docs at `/api/docs/`.
 
-## Expanding the ESLint configuration
+See [`CLAUDE.md`](CLAUDE.md) for full command reference (tests, lint, seed, etc.).
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+## Database schema
+
+PostgreSQL 16. Tables are grouped by Django app; app label differs from module name for `sessions` (Django label is `learning_sessions` to avoid colliding with `django.contrib.sessions`).
+
+```mermaid
+erDiagram
+    accounts_user ||--o{ students_student : owns
+    students_student ||--o{ students_studentskillstate : "mastery per skill"
+    students_student ||--o{ students_studentachievement : earns
+    students_student ||--o{ learning_sessions_session : plays
+    learning_sessions_session ||--o{ exercises_attempt : records
+    skills_skill ||--o{ skills_skillprerequisite : "is dependent"
+    skills_skill ||--o{ skills_skillprerequisite : "is prerequisite"
+    skills_skill ||--o{ exercises_exercisetemplate : "has templates"
+    skills_skill ||--o{ students_studentskillstate : tracked
+    skills_skill ||--o{ exercises_attempt : targeted
+    exercises_exercisetemplate ||--o{ exercises_attempt : instantiated
+```
+
+### `accounts_user` — parent account (AUTH_USER_MODEL)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | bigserial PK | |
+| `email` | varchar, unique | login identifier |
+| `display_name` | varchar(100) | |
+| `password` | varchar | Django-hashed |
+| `is_active`, `is_staff`, `is_superuser` | bool | |
+| `date_joined`, `last_login` | timestamptz | |
+
+### `students_student` — child profile scoped to a parent
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `user_id` | FK → `accounts_user` ON DELETE CASCADE | |
+| `display_name` | varchar(100) | |
+| `grade` | varchar(2) | `P1`…`P6` |
+| `created_at` | timestamptz | |
+| `xp` | int ≥ 0 | gamification |
+| `rank` | varchar(24) | default `curieux` |
+| `current_streak`, `best_streak` | int ≥ 0 | |
+| `last_activity_date` | date, null | |
+| `daily_goal` | smallint ≥ 0 | default 5 |
+
+### `students_studentskillstate` — per-student mastery + SRS state
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | bigserial PK | |
+| `student_id` | FK → `students_student` CASCADE | |
+| `skill_id` | FK → `skills_skill` CASCADE | |
+| `status` | varchar(16) | `not_started` / `in_progress` / `mastered` / `needs_review` |
+| `mastery_level` | float | 0.0–1.0 |
+| `consecutive_correct`, `total_attempts` | int ≥ 0 | |
+| `last_practiced_at`, `next_review_at` | timestamptz, null | spaced-repetition schedule |
+| `review_interval_hours` | int ≥ 0 | default 24 |
+| `updated_at` | timestamptz | |
+
+Unique `(student_id, skill_id)`.
+
+### `students_studentachievement` — badges / milestones
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | bigserial PK | |
+| `student_id` | FK → `students_student` CASCADE | |
+| `code` | varchar(48) | achievement identifier |
+| `earned_at` | timestamptz | |
+| `context` | jsonb | free-form payload |
+
+Unique `(student_id, code)`.
+
+### `skills_skill` — curriculum node (authored in `backend/src/skill_tree/skills.yaml`)
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | varchar(80) PK | YAML slug, e.g. `ADD-01` |
+| `label` | varchar(200) | French display name |
+| `grade` | varchar(4) | `P1`…`P6` |
+| `description` | text | |
+| `mastery_threshold` | smallint | default 3 |
+
+### `skills_skillprerequisite` — DAG edges between skills
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | bigserial PK | |
+| `skill_id` | FK → `skills_skill` CASCADE | |
+| `prerequisite_id` | FK → `skills_skill` CASCADE | |
+
+Unique `(skill_id, prerequisite_id)`. Check `skill_id ≠ prerequisite_id`.
+
+### `exercises_exercisetemplate` — parametric exercise authored in YAML
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | varchar(120) PK | YAML slug |
+| `skill_id` | FK → `skills_skill` CASCADE | **primary skill drilled** |
+| `difficulty` | smallint | check 1–3 |
+| `input_type` | varchar(20) | `number` / `mcq` / `symbol` / `decomposition` / `point_on_line` / `drag_order` |
+| `template` | jsonb | parameter ranges + answer shape |
+
+### `exercises_attempt` — one student answer to one instantiated exercise
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `session_id` | FK → `learning_sessions_session` CASCADE | |
+| `skill_id` | FK → `skills_skill` PROTECT | skill the attempt targeted |
+| `template_id` | FK → `exercises_exercisetemplate` PROTECT | |
+| `input_type` | varchar(20) | snapshotted from template |
+| `exercise_params` | jsonb | concrete params used at instantiation |
+| `student_answer`, `correct_answer` | varchar(200) | |
+| `is_correct` | bool | |
+| `responded_at` | timestamptz | `auto_now_add` |
+
+PROTECT on `skill_id` / `template_id` preserves attempt history even if a skill or template is removed.
+
+### `learning_sessions_session` — wraps a contiguous series of attempts
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | uuid PK | |
+| `student_id` | FK → `students_student` CASCADE | |
+| `mode` | varchar(20) | `learn` / `diagnostic` / `drill` / `exam` |
+| `started_at` | timestamptz | |
+| `ended_at` | timestamptz, null | |
+
+## Notes for contributors
+
+- Skills and exercise templates live in YAML (`backend/src/skill_tree/`) and are seeded via `seed_skills` + `seed_templates`. Edit YAML, then re-seed — never hand-edit the DB.
+- `Student` profiles are always scoped to their owning `User`; all student-facing endpoints enforce ownership via `common.permissions.IsParentOwner`.
+- Session authentication + CSRF. Frontend calls `/api/csrf/` before any mutating request.

--- a/vault/wiki/concepts/product-features.md
+++ b/vault/wiki/concepts/product-features.md
@@ -1,0 +1,58 @@
+---
+title: Product Features
+type: concept
+created: 2026-04-18
+updated: 2026-04-18
+sources: []
+tags: [product, backend, frontend, overview]
+---
+
+Catalog of user-facing and system features currently shipped in PedagogIA. Grouped by surface. Each entry names the feature, what it does, and where it lives in the codebase — so that design / schema / pedagogy discussions can reference a stable list instead of re-deriving it each time.
+
+Snapshot date: **2026-04-18**. Verify against `git log` and `gh issue list` before acting on it — features land fast.
+
+## Learning modes
+
+All four are backed by `apps/sessions` with `Session.mode ∈ {learn, diagnostic, drill, exam}` and attempts recorded in `apps/exercises.Attempt`.
+
+- **Diagnostic** — IRT-scheduled walk that locates the student's current level on the skill tree. Attempts recorded against the targeted skill. See [[concepts/champ-3-arithmetique]] for the skill scope.
+- **Drill** — student (or parent) picks a skill and practices it. Selection of the skill is manual; template selection within the skill is backend-driven.
+- **Training / Free practice** (`mode="learn"`) — mastery + spaced-repetition driven selection via `apps/students/services/selection.py::pick_next_skill`, reading [[concepts/mastery-learning]] state from `StudentSkillState`.
+- **Exam** — timed-ish session with attempts; currently updates mastery like other modes (see #117 for the explicit decision).
+
+## AI & pedagogy
+
+- **AI investigation on wrong answer** — on an incorrect attempt, Claude receives `(question, student answer, skill-tree branch, mastery state)` and reasons about which prerequisite to probe next. Primary model Claude Haiku 4.5; escalation to Sonnet 4.6 via `INVESTIGATION_MODEL_*` settings. No hard-coded error mappings. Natural home for [[concepts/resolution-problemes-math]].
+- **Multi-strategy explanations / hints** — each skill can expose several pedagogical angles (calcul posé, décomposition, …). Delivered through `apps/exercises` + frontend `lib/hints`.
+- **Exercise templates** — parameterized JSONB rows in `ExerciseTemplate`, authored in `backend/src/skill_tree/exercise_templates_p{1..6}.yaml`, instantiated at runtime. New exercises = YAML edit + `seed_templates`. Being refactored to M2M with weights (#117).
+
+## Progress & state
+
+- **Mastery tracking** — `StudentSkillState` stores per-(student, skill) mastery; updated by `apps/students/services/mastery.py::update_mastery`.
+- **XP** — per-attempt XP ledger, `apps/students/services/xp.py`.
+- **Streaks** — daily-practice streak counter, `apps/students/services/streaks.py`.
+- **Achievements** — badge-like unlocks, `apps/students/services/achievements.py` + `students.Achievement` model.
+- **Skill tree visualization** — ReactFlow + dagre layout, reads `StudentSkillState` (see [[concepts/champ-3-arithmetique]] for the DAG content).
+- **Session history / clickable review** — any past session can be re-opened and inspected attempt-by-attempt (landed in #109).
+
+## Parent / account surface
+
+- **Parent dashboard** at `/dashboard` — parent overview screen aggregating child progress (#96, #108).
+- **Parent overview endpoint** `/api/parent/overview/` — source for the dashboard (#93, #95).
+- **CSV / PDF exports** — session-history exports aggregating on `Attempt.skill_id`. Shape-independent of the M2M refactor.
+- **Parent ↔ Student ownership scoping** — `User` (AUTH_USER_MODEL) owns one or more `Student` profiles; all student-facing endpoints enforce ownership via `apps/common` permissions.
+- **Auth** — session-based (SessionAuthentication) with CSRF; Google OAuth via dj-rest-auth + allauth.
+- **Rate limiting on `/api/auth/*`** — app-layer throttling (#99, #118).
+
+## Ops-adjacent
+
+- **Nightly encrypted Postgres backups** to Hetzner Storage Box (#64, #107). Schema-shape-independent.
+- **Two-image production deploy** (`pedagogia-backend` + `pedagogia-frontend`) on [[entities/collegia-be]], see [[concepts/prod-stack]].
+
+## See also
+
+- [[overview]] — top-level project synthesis
+- [[concepts/champ-3-arithmetique]] — POC skill scope
+- [[concepts/mastery-learning]] — theory behind StudentSkillState
+- [[concepts/prod-stack]] — production topology
+- [[questions/nouveaux-types-exercices-ceb]] — planned exercise-type additions not yet shipped

--- a/vault/wiki/index.md
+++ b/vault/wiki/index.md
@@ -57,8 +57,10 @@ Catalog of every wiki page. Updated on every ingest. Keep lines ≤150 chars.
 - [[concepts/resolution-problemes-math]] — Champ 3 headline compétence; natural home for Claude investigation
 - [[concepts/ceb-attendus-p6-arithmetique]] — nine P6-exit arithmetic item types, cross-referenced from CEB 2024
 - [[concepts/prod-stack]] — how prod is wired: two-image Docker split, Caddy front, CI/CD, security baseline
+- [[concepts/product-features]] — catalog of shipped features (modes, AI, progress, parent surface, ops) — 2026-04-18 snapshot
 
 ## Questions
 - [[questions/progression-arithmetique-p1-p6]] — year-by-year arithmetic progression table + skill-tree implications
 - [[questions/nouveaux-types-exercices-ceb]] — 15 types d'exercices à ajouter dans PedagogIA pour couvrir les attendus CEB P6, priorisés en 4 tiers
 - [[questions/ingest-gap-ceb-2008-2018]] — état du dépouillement des 16 CEB : 8 profonds, 2 partiels, 6 placeholders — plan de priorisation
+- [[questions/frontend-ux-audit-2026-04-18]] — 56-finding punch list across 11 screens × 5 viewports; 4 P0 / 36 P1 / 16 P2 + native-app readiness

--- a/vault/wiki/log.md
+++ b/vault/wiki/log.md
@@ -91,3 +91,11 @@ Balayage des 6 CEB placeholders pré-2014. **Découverte majeure** : le CEB a in
 **2008, 2009, 2010** — confirmés pré-séparation par analogie ; non dépouillés en détail (rationale dans `sources/ceb-2008`).
 
 **Impact structural** : le catalogue [[concepts/ceb-attendus-p6-arithmetique]] passe à 82 familles. Stabilité de 13 ans pour les familles data-literacy (2011→2024), 11 ans pour l'arithmétique pure post-séparation (2013→2024). Touché : `sources/ceb-2013` (réécrit ~80 lignes), `sources/ceb-2012`, `sources/ceb-2011`, `sources/ceb-2010`, `sources/ceb-2009`, `sources/ceb-2008`, `concepts/ceb-attendus-p6-arithmetique` (items 78–82 + 7 backdatings), `questions/ingest-gap-ceb-2008-2018`.
+
+## [2026-04-18] note | Product features catalog
+
+Added [[concepts/product-features]] — shipped-feature inventory grouped by surface (learning modes, AI & pedagogy, progress & state, parent surface, ops-adjacent). Cross-references `Session.mode` choices in `apps/sessions/models.py` and services under `apps/students/services/` (mastery, xp, streaks, achievements). Intended as a stable anchor for schema/design discussions (notably the upcoming #119 backend refactor) rather than a changelog — dates feature-by-feature in the page itself. Touched: `concepts/product-features.md` (new), `index.md`.
+
+## [2026-04-18] note | Frontend UX & responsiveness audit
+
+Filed [[questions/frontend-ux-audit-2026-04-18]] — point-in-time audit of 11 screens × 5 viewports (375/390/834/1194/1440), 56 findings (4 P0 / 36 P1 / 16 P2) plus a "native-app readiness" punch list. Method: booted dev stack via `run-app`, created `audit@test.com` + student Léa, ran a one-off Playwright spec for screenshots, statically reviewed every screen + design primitive. Headline: no `<AppShell>` primitive (root cause of duplicated header bugs), no safe-area-inset, no iOS-zoom-prevention on inputs, skill tree unusable on phone (grade buttons truncate, search overflows). Index updated; no entity/concept page created — this is point-in-time analysis, not durable knowledge. Screenshots lived under `/tmp/audit-screenshots/` and were not preserved.

--- a/vault/wiki/questions/frontend-ux-audit-2026-04-18.md
+++ b/vault/wiki/questions/frontend-ux-audit-2026-04-18.md
@@ -1,0 +1,178 @@
+---
+title: Frontend UX & responsiveness audit (2026-04-18)
+type: question
+created: 2026-04-18
+updated: 2026-04-18
+sources: []
+tags: [frontend, ux, design-system, mobile, native-readiness, audit]
+---
+
+> Snapshot dated **2026-04-18** against `main` at commit `78ec9c6`. Re-run before acting — the frontend moves fast and several findings will rot quickly. Screenshots referenced lived under `/tmp/audit-screenshots/` and are not preserved in the vault.
+
+## Original prompt
+
+Audit the frontend of PedagogIA for responsiveness, UX clarity, and readiness for future tablet/phone apps. Output a prioritized punch list — no code changes. Test 11 screens (Welcome, Login, Register, GoogleCallback, ChildPicker, SkillTree, Diagnostic, DiagnosticResult, Drill, Exercise, ParentDashboard) at five viewports: iPhone SE 375×667, iPhone 14 390×844, iPad portrait 834×1194, iPad landscape 1194×834, desktop 1440×900.
+
+## Method
+
+- Booted the dev stack via the `run-app` skill (Postgres + Django + Vite on default ports).
+- Created a test parent (`audit@test.com` / `AuditTest123!`) and one student (`Léa`, P3) directly in the DB.
+- Wrote a one-off Playwright spec walking 12 routes at 5 viewports → 60 full-page screenshots.
+- Read every screen under `frontend/src/components/screens/`, every primitive in `frontend/src/index.css`, and every input under `components/exercises/` for static red flags.
+
+Severity: **P0** = broken / blocks the user · **P1** = bad UX · **P2** = polish.
+
+---
+
+## Per-screen findings
+
+### WelcomeScreen (`/`)
+
+- **P1** Title `Bienvenue dans ta serre, <prénom>.` wraps to 4 lines on 375 px (no responsive size step). → cap with `text-balance` + smaller mobile size.
+- **P1** "Déconnexion" top-right has ≈32 px hit area, no `:active`/`:focus-visible`. → 44×44 hit area + ring.
+- **P2** Action grid `grid-cols-1 md:grid-cols-2` leaves an orphan row on iPad portrait. → `auto-fit` or 3 cols at `md:`.
+- **P2** Footer "Saison · printemps / Changer de carnet" reads as nav but has no separator. → promote to a small bottom toolbar.
+- **P2** "Mon herbier" empty state lacks a CTA to earn first badge. → replace decorative line with an action pill.
+
+### LoginScreen (`/login`)
+
+- **P1** Inputs are 14–15 px → iOS Safari auto-zooms on focus. → enforce `text-base` (16 px).
+- **P1** Missing `autocomplete="email" / "current-password"` and `inputmode`. → add per field.
+- **P1** Wrong-password error renders as a small rose pill below the button — easy to miss on phone. → bump font + `aria-live="polite"`.
+- **P2** Decorative Latin tagline `Ad hortum redi` confuses first-time visitors. → keep but lighten.
+
+### RegisterScreen (`/register`)
+
+- **P1** Same iOS-zoom + autocomplete issues as Login.
+- **P1** No password confirmation, no strength feedback, no `autocomplete="new-password"`.
+- **P2** No GDPR / parental-consent checkbox — mandatory for EU children-under-13 product. → confirm with legal.
+- **P2** "Already have an account?" link too small on phone.
+
+### GoogleCallbackScreen (`/auth/google/callback`)
+
+- **P2** Renders as a near-blank screen with only "Connexion en cours…" spinner. → add Jardin illustration / shimmer.
+- **P2** No timeout / retry path — sits forever on Google error. → catch error param, render "Réessayer" CTA back to /login.
+
+### ChildPickerScreen (`/children`)
+
+- **P1** With one student, `grid-cols-2 sm:grid-cols-3 md:grid-cols-4` leaves a single Pot floating left of a giant void. → `flex flex-wrap justify-center` for single-card state.
+- **P1** Top-right "Espace parent →" + "Se déconnecter" stack vertically on phone, eating half the header column. → unified `<TopBar>` with horizontal layout, icons-only `<sm`.
+- **P1** "Ajouter" submit button is washed-out sage even when valid → reads as disabled. → bind opacity to actual disabled state.
+- **P2** Form inputs (`Prénom`, `P3` select, `Ajouter`) stack as a column on phone — looks like 3 unrelated inputs. → group into a labelled card.
+- **P2** No avatar / color picker on the Pot — every child looks identical (brown soil + green stem).
+
+### ParentDashboardScreen (`/dashboard`)
+
+- **P1** Same vertical-stacked top-right header bug as ChildPicker (`Mode enfant →` / `Se déconnecter`). → shared `<TopBar>`.
+- **P1** Status chips (`0 floraison`, `0 en croissance`, `0 à arroser`, `0 en sommeil`) wrap with the dark `0 en sommeil` chip orphaned below. → horizontal scroll strip or 2×2 grid.
+- **P1** "Voir en détail →" CTA may not route anywhere in current build — verify endpoint. → add real student-detail screen or remove affordance.
+- **P2** Three-stat row `0 XP / 0 série / 0 record` uses `text-3xl` — competes with screen title. → reduce to `text-xl`.
+- **P2** Empty state "Aucune session pour le moment." is unstyled italic. → reuse a shared `<EmptyState>` component.
+
+### SkillTreeScreen (`/skill-tree`)
+
+- **P0** Header on 375 px **truncates the grade buttons**: `P1`, `P2`, half of `P3`, `P4/P5/P6` clipped — user can't switch grade. → collapse grades into `<select>` or scroll-snap strip on `<sm`.
+- **P0** Search input has hardcoded `!w-64` → pushes header off-screen on phone, competes with `Vue d'ensemble` on iPad portrait. → `w-full sm:w-64 max-w-full`.
+- **P0** ReactFlow `panOnDrag` + `zoomOnPinch` fights iOS native scroll on touch — no gesture cue. → add a first-visit gesture hint, gate `panOnScroll` behind pointer media.
+- **P1** Skill node labels unreadable on phone (≈9–10 px). The whole map is unusable below tablet width. → ship a list-view fallback for `<sm`, or auto-zoom to current grade on mount.
+- **P1** Locked-skill tooltip is `group-hover:opacity-100` — invisible on touch. → always-on lock icon + tap-to-reveal panel.
+- **P1** Status legend overlaps the zoom controls on phone (visible in `iphonese-07`). → move bottom-left or hide `<sm`.
+- **P1** No keyboard navigation between nodes — accessibility blocker.
+- **P2** `← Serre` back link is the smallest text in the header.
+- **P2** Minimap hidden `<md` with no replacement. → thin top progress bar showing scroll position.
+
+### DiagnosticScreen (`/diagnostic`)
+
+- **P1** Equation `395 + 258 = ?` wraps the `?` to a second line on 375 px. → `flex-wrap` with min-width chunks or shrink font on narrow screens.
+- **P1** Desktop view leaves `LevelGauge` floating alone in the right gutter at ≈1300 px. → anchor to the card or move to top progress strip.
+- **P1** "Question 1 / 25" + duplicate "1 / 25" on the right of the progress bar — same info twice. → drop the redundant counter.
+- **P2** No "passer" affordance; "Quitter" abandons the whole diagnostic without confirmation. → add confirm dialog + skip option.
+- **P2** `Locus discendi` Latin tagline competes with the title on small screens.
+
+### DiagnosticResult (end of `/diagnostic`)
+
+*Static analysis only — couldn't reach via screenshot script without finishing 25 questions.*
+
+- **P1** SVG verdict circle hardcoded `140×140`. → `viewBox` + `clamp()`.
+- **P1** `grid-cols-3` count cards have no `sm:` fallback → labels truncate at 320–375 px.
+- **P2** No "share with parent" affordance — diagnostic outcome's audience is the parent.
+
+### DrillScreen (`/drill`)
+
+- **P1** No skill picker UI on entry — drops straight into a question with no context (which skill, how many questions). → add a chip near the title.
+- **P1** "Demander un indice" pill sits below "Valider" — kids will tap Validate by reflex. → swap order, or surface hint inline after wrong answer.
+- **P2** "best 0" XP chip top-right competes with the progress bar.
+
+### ExerciseScreen (`/exercise`)
+
+- **P1** NumberPad `0` and `,` (comma) look identical at a glance. → swap `,` for a labelled "↵" or differentiate color.
+- **P1** Backspace icon (⌫) is 18 px in a 60 px button — looks decorative. → bump to ≈28 px.
+- **P1** "Valider" disabled state is indistinguishable from active. → dotted outline / clearer opacity, or remove disabled and validate inline.
+- **P1** No haptic / sound feedback hooks — non-blocking on web but plan for native. → add `feedbackChannel` abstraction now.
+- **P2** "Établi · Léa" header is right-aligned + small; only "back" is "Arrêter" on left. → standardise via shared TopBar.
+- **P2** Question text uses `text-5xl` — forces wrapping (`383 + 127 = ?` breaks before `?` on 375 px). → reduce on `<sm`.
+
+### HistoryScreen (`/history`)
+
+- **P1** "Exporter PDF" / "Exporter JSON" shown as primary CTAs while there's literally nothing to export. → hide until ≥1 session exists.
+- **P1** Empty state copy "Commence par un test de niveau ou un entraînement" is plain text — not actionable. → make those words links / chips.
+- **P2** Row `hover:bg-mist/60` doesn't fire on touch; no `:active` state. → add `active:bg-mist/80`.
+- **P2** Icon buttons (export, delete) are 18 px in tight spacing — tap targets <44 px. → add `p-2` padding shell.
+
+### ProfileScreen (`/profile`)
+
+- **P2** "Mon herbier" badge grid shows 16 grayed-out icons with identical sigma symbols — visually monotonous. → vary stroke / subtitle weight per category, group with section headers.
+- **P2** Stats card duplicates info from Welcome (XP, daily goal). → either collapse Welcome's stats or differentiate Profile with history/streak chart.
+- **P2** No edit affordance for student name / grade.
+
+---
+
+## Cross-cutting issues
+
+- **P0** **No top-level layout primitive.** Every screen reinvents header padding, `max-w`, and back-button shape. Direct cause of the duplicated header-stacking bug on ChildPicker + ParentDashboard, and divergent "Quitter / Retour / ← Serre" labels everywhere. → introduce `<AppShell>` with `<TopBar leading slot trailing>` + `<Page maxWidth>`.
+- **P1** **No `safe-area-inset-*` CSS anywhere.** Screens use `min-h-screen` / `h-screen` directly. iPhone notch will overlap headers; Android gesture nav will overlap bottom CTAs. → `viewport-fit=cover` + `env(safe-area-inset-*)` padding in AppShell.
+- **P1** **No iOS-zoom-prevention on form inputs.** All inputs are 14–15 px. → 16 px base.
+- **P1** **No `autocomplete` / `inputmode` discipline.** Affects login/register/childpicker forms and all numeric exercise inputs.
+- **P1** **Inconsistent top-right wording** (`Déconnexion` / `Se déconnecter` / `Mode enfant`) across Welcome, ChildPicker, ParentDashboard. → centralise label + iconography.
+- **P1** **Hover-only affordances** on SkillNode (locked tooltip), HistoryRow (highlight), ChildPicker Pot (lift) — touch users get stuck-hover or no feedback. → mirror with `:active`, prefer `:focus-visible`.
+- **P1** **Skill tree gestures will not survive on touch.** Map unusable on phones. → list view alternative for `<md`.
+- **P1** **Empty states are decorative-italic, not actionable.** Pattern across HistoryScreen, ParentDashboard, WelcomeScreen herbier. → shared `<EmptyState icon title body cta>` component.
+- **P1** **Disabled-button styling = `bg-sage/40` washed-out.** Indistinguishable from muted active. → dashed border + lower opacity, or avoid disabled and validate inline.
+- **P2** **Grid-cols transitions skip `sm:`.** Most grids go `grid-cols-1 md:grid-cols-N` directly; 640–767 px gets the mobile layout despite plenty of room.
+- **P2** **No global loading skeletons** — every screen uses `text-stem` "Chargement…". → shimmer skeletons matching final layout.
+- **P2** **`text-balance` not used on display titles.** Tailwind 4 supports it.
+- **P2** **No focus-visible ring on icon-only buttons** — tab navigation is invisible.
+- **P2** **Tabular numerals already loaded but not applied to score / XP digits.** → `font-variant-numeric: tabular-nums` on chip values.
+- **P2** **No PWA manifest, no service worker, no offline copy.** Defer until punchlist clears.
+
+---
+
+## Native-app readiness (RN port / PWA shell)
+
+What needs to change *structurally* before a React Native port or a serious PWA install makes sense, in priority order:
+
+1. **Introduce `<AppShell>` + navigation primitives now.** Today every screen owns its header/back/CTA layout; in RN these map to `<Stack.Screen options>`. Centralise into `AppShell`, `TopBar` (leading + title + trailing), `BottomBar` (optional). Single highest-leverage refactor — also fixes most cross-cutting P0/P1 above.
+2. **Pick a navigation pattern.** `react-router` v7 doesn't translate to RN. Decide tab bar (Welcome / Skill tree / History / Profile) vs. stack-only, then make the URL → screen map already work that way.
+3. **Replace ReactFlow on touch or build a list fallback.** ReactFlow is web-only and fragile on touch even in PWA. Either keep RF + add list view for `<md` (reusable from RN), or reimplement later with `react-native-skia`. The list view buys both.
+4. **Network layer behind a `client` module that already handles "no network".** Today fetches throw; RN needs offline tolerance. Add a TanStack Query persister + per-screen offline banner.
+5. **Externalise feedback (sound, haptic, animation) behind a hook.** `useFeedback().correct() / .wrong()`. Web noop today; on RN maps to `Haptics.impactAsync`.
+6. **Drop hover-dependent affordances.** Already P1 above; doing it before the port saves a UX retest.
+7. **Adopt safe-area-inset everywhere via AppShell.** Maps 1:1 to RN's `useSafeAreaInsets()`.
+8. **Standardise font-loading.** Fraunces / Inter / JetBrains Mono need a strategy that survives an RN bundle (Expo Font / Asset). Today CDN-loaded — fine for web, breaks offline.
+9. **Pull strings out of JSX.** A future i18n / Flemish-Dutch variant is plausible (Belgium); also reusable across web + native.
+10. **Audit `<input>` types for native equivalents.** Whatever has a story on native (`numeric`, `decimal-pad`, `email-address`) should already use the correct `inputmode` + `type` on web — that becomes the source of truth for RN `keyboardType`.
+
+What does **not** need to change yet: the design tokens (`--color-*`, radii, shadows) translate cleanly to RN via a small theme file; the `renderInput` switch in `ExerciseCard` is the right factoring for native; Zustand stores port as-is; auth model is fine for RN with a thin token-vs-session adapter.
+
+---
+
+**Total: 56 findings — 4 P0 · 36 P1 · 16 P2.**
+
+## Filed under
+
+[[concepts/product-features]] — UX context for the features catalogued there.
+
+## See also
+
+- The Jardin design system spec lives outside the wiki (in `CLAUDE.md` "Design System" section + `design/JARDIN.html`); not duplicated here.
+- If a follow-up rebuild lands an `<AppShell>`, supersede the cross-cutting P0 finding here with a `> ⚠ Conflict:` note rather than silent edit.


### PR DESCRIPTION
## Summary
- `README.md`: replaces the leftover Vite template with a real PedagogIA intro (live URL, doc pointers, quickstart).
- `vault/wiki/questions/frontend-ux-audit-2026-04-18.md`: files the 56-finding responsiveness audit (4 P0 / 36 P1 / 16 P2) so the analysis survives outside chat history. Source for issues #120–#123.
- `vault/wiki/concepts/product-features.md`: 2026-04-18 snapshot of every shipped feature, grouped by surface.
- `index.md` + `log.md` updated with one-line hooks for the two new pages.

Pure docs / vault content — no code paths touched.

## Test plan
- [ ] `gh pr view` renders cleanly
- [ ] No CI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)