### PR TITLE
feat(#121): skill tree usable on phone and small tablets

### DIFF
--- a/frontend/e2e/skilltree-mobile.spec.js
+++ b/frontend/e2e/skilltree-mobile.spec.js
@@ -1,0 +1,86 @@
+import { test, expect } from "@playwright/test"
+
+const VIEWPORTS = [
+  { name: "phone", width: 375, height: 812 },
+  { name: "tablet", width: 834, height: 1112 },
+  { name: "desktop", width: 1440, height: 900 },
+]
+
+async function signUpAndPickChild(page) {
+  const email = `tree-mobile-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@example.com`
+  await page.goto("/register")
+  await page.getByTestId("register-name").fill("Camille")
+  await page.getByTestId("register-email").fill(email)
+  await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-submit").click()
+  await expect(page).toHaveURL(/\/children/)
+
+  await page.getByTestId("child-name").fill("Noé")
+  await page.getByTestId("child-grade").selectOption("P3")
+  await page.getByTestId("child-add").click()
+  await expect(
+    page.getByTestId("children-list").locator("[data-testid^='child-']")
+  ).toHaveCount(1)
+  await page.getByTestId("children-list").locator("button").first().click()
+  await expect(page).toHaveURL(/\/$|\/welcome/)
+}
+
+for (const vp of VIEWPORTS) {
+  test(`skill tree has no horizontal overflow and header fits at ${vp.name} (${vp.width}px)`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: vp.width, height: vp.height })
+    await signUpAndPickChild(page)
+
+    await page.goto("/skill-tree")
+    await expect(page.getByRole("heading", { name: /carte des espèces/i })).toBeVisible()
+    await page.waitForTimeout(500)
+
+    const scroll = await page.evaluate(() => ({
+      docWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+    }))
+    expect(scroll.docWidth).toBeLessThanOrEqual(scroll.clientWidth + 1)
+
+    if (vp.width < 640) {
+      await expect(page.getByLabel(/filtrer par année/i)).toBeVisible()
+    } else {
+      await expect(page.getByRole("button", { name: /vue d'ensemble/i })).toBeVisible()
+      await expect(page.getByRole("button", { name: /^P3$/ })).toBeVisible()
+      await expect(page.getByRole("button", { name: /^P6$/ })).toBeVisible()
+    }
+  })
+}
+
+test("mobile list-view fallback renders skills grouped by grade", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await signUpAndPickChild(page)
+  await page.goto("/skill-tree")
+  await expect(page.getByRole("heading", { name: /carte des espèces/i })).toBeVisible()
+
+  await expect(page.getByRole("heading", { name: /^P1$/ })).toBeVisible()
+  const skillButtons = page.locator("button[data-skill-id]")
+  await expect(skillButtons.first()).toBeVisible()
+  expect(await skillButtons.count()).toBeGreaterThan(5)
+
+  await skillButtons.first().click()
+  await expect(page.getByTestId("skill-detail-panel")).toBeVisible()
+})
+
+test("desktop keyboard navigation: arrow keys move focus, Enter opens detail", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await signUpAndPickChild(page)
+  await page.goto("/skill-tree")
+  await expect(page.getByRole("heading", { name: /carte des espèces/i })).toBeVisible()
+  await page.waitForTimeout(800)
+
+  const flow = page.getByRole("application", { name: /carte interactive/i })
+  await flow.click()
+  await flow.focus()
+
+  await page.keyboard.press("ArrowRight")
+  await page.keyboard.press("ArrowRight")
+  await page.keyboard.press("Enter")
+
+  await expect(page.getByTestId("skill-detail-panel")).toBeVisible()
+})

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -17,6 +17,7 @@ import { useAuthStore } from "../../stores/authStore"
 import { useSkillTree } from "../../hooks/useSkillTree"
 import AppShell from "../layout/AppShell"
 import SkillNode from "../ui/SkillNode"
+import SkillListView from "../ui/SkillListView"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
@@ -26,6 +27,7 @@ import { GRADES, buildGraph } from "../../lib/skillTreeLayout"
 import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
 
 const EMPTY_SET = new Set()
+const MOBILE_BREAKPOINT = 768
 
 function LaneLabel({ data }) {
   const { grade, colors, width, height } = data
@@ -70,9 +72,24 @@ function pickFocusSkill(skills, stateById) {
   return best?.id ?? null
 }
 
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(
+    typeof window !== "undefined" ? window.innerWidth < MOBILE_BREAKPOINT : false
+  )
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`)
+    const handler = (e) => setIsMobile(e.matches)
+    mql.addEventListener("change", handler)
+    return () => mql.removeEventListener("change", handler)
+  }, [])
+  return isMobile
+}
+
 function SkillTreeInner({ skills, skillTreeData, isLoading }) {
   const navigate = useNavigate()
-  const { fitView } = useReactFlow()
+  const { fitView, setCenter, getZoom } = useReactFlow()
+  const isMobile = useIsMobile()
 
   const children = useAuthStore((s) => s.children)
   const selectedChildId = useAuthStore((s) => s.selectedChildId)
@@ -91,6 +108,12 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
     () => (skills ? pickFocusSkill(skills, stateById) : null),
     [skills, stateById]
   )
+
+  const skillsById = useMemo(() => {
+    const map = new Map()
+    for (const s of skills ?? []) map.set(s.id, s)
+    return map
+  }, [skills])
 
   const { nodes: initialNodes, edges: initialEdges, bounds } = useMemo(
     () =>
@@ -140,6 +163,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
   const [query, setQuery] = useState("")
   const [searchOpen, setSearchOpen] = useState(false)
   const [gradeFilter, setGradeFilter] = useState(null)
+  const [focusedNodeId, setFocusedNodeId] = useState(null)
   const hoverContext = useMemo(() => ({ hoveredId: null, prereqs: EMPTY_SET }), [])
 
   const centeredRef = useRef(false)
@@ -147,7 +171,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
   const onInit = useCallback(() => setRfReady(true), [])
 
   useEffect(() => {
-    if (centeredRef.current || !rfReady || !initialNodes.length) return
+    if (isMobile || centeredRef.current || !rfReady || !initialNodes.length) return
     const skillNodes = initialNodes.filter((n) => n.type === "skillNode")
     if (!skillNodes.length) return
     const focus = skillNodes.find((n) => n.id === focusId)
@@ -169,7 +193,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
         duration: 600
       })
     }, 50)
-  }, [rfReady, initialNodes, focusId, currentChild, fitView])
+  }, [rfReady, initialNodes, focusId, currentChild, fitView, isMobile])
 
   const applyFilter = useCallback(
     (q, grade) => {
@@ -200,6 +224,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
   const onNodeClick = useCallback((_, node) => {
     if (node.type !== "skillNode") return
     setSelected(node.data)
+    setFocusedNodeId(node.id)
   }, [])
 
   const onPaneClick = useCallback(() => {
@@ -224,6 +249,15 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
     [applyFilter, gradeFilter, query]
   )
 
+  const onGradeSelectChange = useCallback(
+    (e) => {
+      const v = e.target.value || null
+      setGradeFilter(v)
+      applyFilter(query, v)
+    },
+    [applyFilter, query]
+  )
+
   const onOverview = useCallback(() => {
     fitView({ padding: 0.05, duration: 500 })
     setSelected(null)
@@ -233,6 +267,89 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
     (node) => node.data?.colors?.minimap ?? "#A1AEA3",
     []
   )
+
+  const selectById = useCallback(
+    (id) => {
+      const n = nodes.find((x) => x.id === id && x.type === "skillNode")
+      if (!n) return
+      setSelected(n.data)
+      setFocusedNodeId(id)
+    },
+    [nodes]
+  )
+
+  const onListSelect = useCallback((data) => {
+    setSelected(data)
+    setFocusedNodeId(data.id)
+  }, [])
+
+  const visibleSkillNodes = useMemo(
+    () => nodes.filter((n) => n.type === "skillNode" && (n.style?.opacity ?? 1) > 0.5),
+    [nodes]
+  )
+
+  const onKeyDown = useCallback(
+    (e) => {
+      if (!visibleSkillNodes.length) return
+      const target = e.target
+      const tag = target?.tagName
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return
+      const k = e.key
+      const isArrow = k === "ArrowUp" || k === "ArrowDown" || k === "ArrowLeft" || k === "ArrowRight"
+      const isEnter = k === "Enter"
+      if (!isArrow && !isEnter) return
+
+      if (isEnter) {
+        if (focusedNodeId) {
+          e.preventDefault()
+          selectById(focusedNodeId)
+        }
+        return
+      }
+
+      e.preventDefault()
+      const cur = visibleSkillNodes.find((n) => n.id === focusedNodeId)
+      if (!cur) {
+        setFocusedNodeId(visibleSkillNodes[0].id)
+        return
+      }
+
+      const dx = k === "ArrowLeft" ? -1 : k === "ArrowRight" ? 1 : 0
+      const dy = k === "ArrowUp" ? -1 : k === "ArrowDown" ? 1 : 0
+      const cx = cur.position.x
+      const cy = cur.position.y
+
+      let best = null
+      let bestScore = Infinity
+      for (const n of visibleSkillNodes) {
+        if (n.id === cur.id) continue
+        const ddx = n.position.x - cx
+        const ddy = n.position.y - cy
+        const primary = dx !== 0 ? ddx * dx : ddy * dy
+        if (primary <= 0) continue
+        const orthogonal = dx !== 0 ? Math.abs(ddy) : Math.abs(ddx)
+        const score = primary + orthogonal * 2
+        if (score < bestScore) {
+          bestScore = score
+          best = n
+        }
+      }
+      if (best) {
+        setFocusedNodeId(best.id)
+        setCenter(best.position.x + 70, best.position.y + 85, {
+          zoom: getZoom(),
+          duration: 250,
+        })
+      }
+    },
+    [visibleSkillNodes, focusedNodeId, selectById, setCenter, getZoom]
+  )
+
+  const focusStyle = useMemo(() => {
+    if (!focusedNodeId) return null
+    const safe = focusedNodeId.replace(/["\\]/g, "\\$&")
+    return `.react-flow__node[data-id="${safe}"] .specimen { outline: 2px solid #3F6F4A; outline-offset: 3px; border-radius: 18px; }`
+  }, [focusedNodeId])
 
   if (isLoading) {
     return (
@@ -246,114 +363,170 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
 
   return (
     <AppShell surface="plain" className="overflow-hidden">
-      <header className="flex items-center gap-3 px-4 md:px-6 py-3 border-b border-sage/10 bg-paper">
-        <a href="/" className="text-sage-deep hover:underline text-sm font-semibold shrink-0">
-          ← Serre
-        </a>
-        <div className="hidden md:block shrink-0">
-          <LatinLabel>Hortus mathematicus</LatinLabel>
-          <h1 className="font-display font-semibold text-lg text-bark leading-tight">
+      <header className="border-b border-sage/10 bg-paper">
+        <div className="flex items-center gap-2 px-3 sm:px-4 md:px-6 py-3 min-w-0">
+          <a
+            href="/"
+            className="text-sage-deep hover:underline text-sm font-semibold shrink-0"
+          >
+            ← Serre
+          </a>
+          <div className="hidden lg:block shrink-0 ml-1">
+            <LatinLabel>Hortus mathematicus</LatinLabel>
+            <h1 className="font-display font-semibold text-lg text-bark leading-tight">
+              Carte des espèces
+            </h1>
+          </div>
+          <h1 className="lg:hidden font-display font-semibold text-base text-bark leading-tight truncate">
             Carte des espèces
           </h1>
-        </div>
-        <div className="flex items-center gap-1 ml-2 overflow-x-auto">
-          {GRADES.map((g) => (
-            <button
-              key={g}
-              onClick={() => selectGrade(g)}
-              className={`navlink shrink-0 ${gradeFilter === g ? "active" : ""}`}
-            >
-              {g}
-            </button>
-          ))}
-        </div>
-        <div className="ml-auto flex items-center gap-2">
-          <button
-            onClick={onOverview}
-            className="pill pill-ghost !py-2 !px-3 !text-xs"
-            aria-label="Vue d'ensemble"
-          >
-            Vue d'ensemble
-          </button>
-          <div className="hidden md:block">
-            <Input
-              type="search"
-              value={query}
-              onChange={onQueryChange}
-              placeholder="Rechercher une plante…"
-              className="!w-64"
-            />
+
+          <div className="hidden sm:flex items-center gap-1 ml-2 overflow-x-auto min-w-0">
+            {GRADES.map((g) => (
+              <button
+                key={g}
+                onClick={() => selectGrade(g)}
+                className={`navlink shrink-0 ${gradeFilter === g ? "active" : ""}`}
+                aria-pressed={gradeFilter === g}
+              >
+                {g}
+              </button>
+            ))}
           </div>
+          <select
+            aria-label="Filtrer par année"
+            className="sm:hidden ml-auto rounded-full border border-sage/25 bg-paper text-bark text-sm px-3 py-1.5 max-w-[9rem]"
+            value={gradeFilter ?? ""}
+            onChange={onGradeSelectChange}
+          >
+            <option value="">Toutes les années</option>
+            {GRADES.map((g) => (
+              <option key={g} value={g}>
+                {g} · {levelDescriptions[g]}
+              </option>
+            ))}
+          </select>
+
+          <div className="hidden sm:flex items-center gap-2 ml-auto shrink-0">
+            <button
+              onClick={onOverview}
+              className="pill pill-ghost !py-2 !px-3 !text-xs"
+              aria-label="Vue d'ensemble"
+            >
+              Vue d'ensemble
+            </button>
+            <div className="hidden md:block">
+              <Input
+                type="search"
+                value={query}
+                onChange={onQueryChange}
+                placeholder="Rechercher une plante…"
+                className="w-full sm:w-64 max-w-full"
+              />
+            </div>
+            <button
+              onClick={() => setSearchOpen((v) => !v)}
+              className="md:hidden navlink !p-2"
+              aria-label="Rechercher"
+              aria-expanded={searchOpen}
+            >
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+                <circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" />
+              </svg>
+            </button>
+          </div>
+
           <button
             onClick={() => setSearchOpen((v) => !v)}
-            className="md:hidden navlink !p-2"
+            className="sm:hidden navlink !p-2 shrink-0"
             aria-label="Rechercher"
+            aria-expanded={searchOpen}
           >
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
               <circle cx="11" cy="11" r="7" /><path d="m20 20-3.5-3.5" />
             </svg>
           </button>
         </div>
+
+        {searchOpen && (
+          <div className="md:hidden px-3 sm:px-4 py-2 border-t border-sage/10">
+            <Input
+              type="search"
+              value={query}
+              onChange={onQueryChange}
+              placeholder="Rechercher une plante…"
+              autoFocus
+              className="w-full max-w-full"
+            />
+          </div>
+        )}
       </header>
 
-      {searchOpen && (
-        <div className="md:hidden px-4 py-2 border-b border-sage/10 bg-paper">
-          <Input
-            type="search"
-            value={query}
-            onChange={onQueryChange}
-            placeholder="Rechercher une plante…"
-            autoFocus
-          />
+      {isMobile ? (
+        <SkillListView
+          nodes={nodes}
+          gradeFilter={gradeFilter}
+          onSelect={onListSelect}
+          selectedId={selected?.id}
+          focusedId={focusedNodeId}
+        />
+      ) : (
+        <div
+          ref={flowRef}
+          className="flex-1 relative outline-none"
+          tabIndex={0}
+          onKeyDown={onKeyDown}
+          role="application"
+          aria-label="Carte interactive des compétences"
+        >
+          {focusStyle && <style>{focusStyle}</style>}
+          <SkillTreeHoverContext.Provider value={hoverContext}>
+            <ReactFlow
+              nodes={nodes}
+              edges={edges}
+              onNodesChange={onNodesChange}
+              onEdgesChange={onEdgesChange}
+              onNodeClick={onNodeClick}
+              onPaneClick={onPaneClick}
+              onInit={onInit}
+              nodeTypes={nodeTypes}
+              minZoom={minZoom}
+              maxZoom={1.5}
+              translateExtent={translateExtent}
+              panOnScroll
+              zoomOnScroll={false}
+              zoomOnPinch
+              panOnDrag
+              proOptions={{ hideAttribution: true }}
+            >
+              <Background color="rgba(63, 111, 74, 0.18)" gap={22} size={1} />
+              <Controls position="bottom-right" showInteractive={false} />
+              <div className="hidden md:block">
+                <MiniMap
+                  nodeColor={minimapColor}
+                  maskColor="rgba(246, 248, 243, 0.7)"
+                  position="bottom-left"
+                  pannable
+                  zoomable
+                />
+              </div>
+            </ReactFlow>
+          </SkillTreeHoverContext.Provider>
+
+          <StatusLegend />
         </div>
       )}
 
-      <div ref={flowRef} className="flex-1 relative">
-        <SkillTreeHoverContext.Provider value={hoverContext}>
-        <ReactFlow
-          nodes={nodes}
-          edges={edges}
-          onNodesChange={onNodesChange}
-          onEdgesChange={onEdgesChange}
-          onNodeClick={onNodeClick}
-          onPaneClick={onPaneClick}
-          onInit={onInit}
-          nodeTypes={nodeTypes}
-          minZoom={minZoom}
-          maxZoom={1.5}
-          translateExtent={translateExtent}
-          panOnScroll
-          zoomOnScroll={false}
-          zoomOnPinch
-          panOnDrag
-          proOptions={{ hideAttribution: true }}
-        >
-          <Background color="rgba(63, 111, 74, 0.18)" gap={22} size={1} />
-          <Controls position="bottom-right" showInteractive={false} />
-          <div className="hidden md:block">
-            <MiniMap
-              nodeColor={minimapColor}
-              maskColor="rgba(246, 248, 243, 0.7)"
-              position="bottom-left"
-              pannable
-              zoomable
-            />
-          </div>
-        </ReactFlow>
-        </SkillTreeHoverContext.Provider>
-
-        {selected && (
-          <DetailPanel
-            skill={selected}
-            state={stateById.get(selected.id)}
-            onClose={onPaneClick}
-            onPractice={(id) =>
-              navigate(`/exercise?skill=${encodeURIComponent(id)}`)
-            }
-          />
-        )}
-        <StatusLegend />
-      </div>
+      {selected && (
+        <DetailPanel
+          skill={selected}
+          state={stateById.get(selected.id)}
+          skillsById={skillsById}
+          masteryById={stateById}
+          onClose={() => setSelected(null)}
+          onPractice={(id) => navigate(`/exercise?skill=${encodeURIComponent(id)}`)}
+        />
+      )}
     </AppShell>
   )
 }
@@ -392,7 +565,10 @@ function StatusLegend() {
     { label: "En sommeil", color: "#A1AEA3" },
   ]
   return (
-    <Card className="hidden md:flex absolute bottom-4 right-20 flex-col gap-1.5 px-3 py-2.5">
+    <Card
+      className="hidden md:flex absolute top-4 left-4 z-10 flex-col gap-1.5 px-3 py-2.5"
+      aria-label="Légende"
+    >
       {items.map(({ label, color }) => (
         <div key={label} className="flex items-center gap-2 text-[11px] text-bark">
           <span className="w-2.5 h-2.5 rounded-full" style={{ background: color }} />
@@ -403,12 +579,24 @@ function StatusLegend() {
   )
 }
 
-function DetailPanel({ skill, state, onClose, onPractice }) {
+function DetailPanel({ skill, state, skillsById, masteryById, onClose, onPractice }) {
   const pct = state ? Math.round(state.mastery_level * 100) : 0
   const attempts = state?.total_attempts ?? 0
+  const missingPrereqs = useMemo(() => {
+    if (skill.unlocked) return []
+    return (skill.prerequisites ?? [])
+      .map((pid) => ({
+        id: pid,
+        skill: skillsById?.get(pid),
+        mastered: masteryById?.get(pid)?.status === "mastered",
+      }))
+      .filter((p) => !p.mastered && p.skill)
+  }, [skill, skillsById, masteryById])
+
   return (
     <Card
       variant="tag"
+      data-testid="skill-detail-panel"
       className="absolute top-4 left-4 right-4 md:left-auto md:right-4 md:w-80 p-5 z-50 bg-paper"
     >
       <div className="flex items-start justify-between mb-3">
@@ -456,10 +644,30 @@ function DetailPanel({ skill, state, onClose, onPractice }) {
           Arroser cette plante
         </Button>
       )}
-      {onPractice && !skill.unlocked && (
-        <p className="mt-3 text-xs text-stem italic">
-          Maîtrise d'abord les racines de cette plante.
-        </p>
+      {!skill.unlocked && (
+        <div className="mt-4 rounded-xl bg-mist/60 border border-sage/15 px-3 py-2.5">
+          <div className="text-xs font-semibold text-bark mb-1">
+            Pas encore accessible
+          </div>
+          {missingPrereqs.length > 0 ? (
+            <>
+              <p className="text-[11px] text-stem leading-relaxed">
+                Maîtrise d'abord {missingPrereqs.length > 1 ? "ces racines" : "cette racine"} :
+              </p>
+              <ul className="mt-1.5 space-y-0.5">
+                {missingPrereqs.map((p) => (
+                  <li key={p.id} className="text-[11px] text-bark">
+                    · {p.skill.label}
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p className="text-[11px] text-stem italic">
+              Maîtrise d'abord les racines de cette plante.
+            </p>
+          )}
+        </div>
       )}
     </Card>
   )

--- a/frontend/src/components/ui/SkillListView.jsx
+++ b/frontend/src/components/ui/SkillListView.jsx
@@ -1,0 +1,140 @@
+import { useMemo } from "react"
+import { GRADES, GRADE_COLORS } from "../../lib/skillTreeLayout"
+import { levelDescriptions, levelLatin, levelVernacular } from "../../lib/constants"
+
+const STATE_LABEL = {
+  floraison: "Floraison",
+  croissance: "En croissance",
+  arroser: "À arroser",
+  sommeil: "En sommeil",
+}
+
+const STATE_COLOR = {
+  floraison: "#E8C66A",
+  croissance: "#6FA274",
+  arroser: "#4F8BAC",
+  sommeil: "#A1AEA3",
+}
+
+const STATUS_TO_STATE = {
+  completed: "floraison",
+  in_progress: "croissance",
+  review: "arroser",
+  locked: "sommeil",
+}
+
+function LockIcon({ className = "" }) {
+  return (
+    <svg
+      className={className}
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="4" y="11" width="16" height="10" rx="2" />
+      <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+    </svg>
+  )
+}
+
+export default function SkillListView({
+  nodes,
+  gradeFilter,
+  onSelect,
+  selectedId,
+  focusedId,
+}) {
+  const byGrade = useMemo(() => {
+    const map = new Map(GRADES.map((g) => [g, []]))
+    for (const n of nodes) {
+      if (n.type !== "skillNode") continue
+      const g = n.data.grade
+      if (!map.has(g)) continue
+      if (gradeFilter && g !== gradeFilter) continue
+      map.get(g).push(n)
+    }
+    return map
+  }, [nodes, gradeFilter])
+
+  return (
+    <div className="flex-1 overflow-y-auto px-4 py-4 space-y-6">
+      {GRADES.map((grade) => {
+        const items = byGrade.get(grade) ?? []
+        if (!items.length) return null
+        const colors = GRADE_COLORS[grade]
+        return (
+          <section key={grade} aria-labelledby={`grade-${grade}`}>
+            <header
+              className="flex items-baseline gap-2 mb-2 pb-1.5 border-b"
+              style={{ borderColor: `${colors.border}40` }}
+            >
+              <h2
+                id={`grade-${grade}`}
+                className="font-display font-semibold text-base"
+                style={{ color: colors.text }}
+              >
+                {grade}
+              </h2>
+              <span className="latin text-[11px]">{levelLatin[grade]}</span>
+              <span className="text-[11px] text-stem ml-auto">
+                {levelDescriptions[grade]} · {levelVernacular[grade]}
+              </span>
+            </header>
+            <ul className="space-y-1.5">
+              {items.map((n) => {
+                const d = n.data
+                const state = STATUS_TO_STATE[d.status] ?? "sommeil"
+                const pct = Math.round((d.masteryLevel ?? 0) * 100)
+                const attempts = d.totalAttempts ?? 0
+                const locked = !d.unlocked
+                const isSelected = selectedId === d.id
+                const isFocused = focusedId === d.id
+                return (
+                  <li key={n.id}>
+                    <button
+                      type="button"
+                      data-skill-id={d.id}
+                      data-focused={isFocused ? "true" : undefined}
+                      aria-pressed={isSelected}
+                      onClick={() => onSelect(d)}
+                      className={`w-full flex items-center gap-3 text-left rounded-xl px-3 py-2.5 bg-paper border transition-colors ${isSelected ? "border-sage-deep" : isFocused ? "border-sage" : "border-sage/15"} ${locked ? "opacity-70" : ""}`}
+                    >
+                      <span
+                        className="w-2.5 h-2.5 rounded-full shrink-0"
+                        style={{ background: STATE_COLOR[state] }}
+                        aria-hidden="true"
+                      />
+                      <span className="min-w-0 flex-1">
+                        <span className="flex items-center gap-1.5 text-sm font-semibold text-bark leading-tight">
+                          {locked && (
+                            <LockIcon className="text-stem shrink-0" />
+                          )}
+                          <span className="truncate">{d.label}</span>
+                        </span>
+                        <span className="block latin text-[10px] mt-0.5">
+                          {d.family} · {STATE_LABEL[state]}
+                          {attempts > 0 ? ` · ${pct}%` : ""}
+                        </span>
+                      </span>
+                      {attempts > 0 && (
+                        <span className="font-mono text-xs text-sage-deep tabular-nums shrink-0">
+                          {pct}%
+                        </span>
+                      )}
+                    </button>
+                  </li>
+                )
+              })}
+            </ul>
+          </section>
+        )
+      })}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/SkillNode.jsx
+++ b/frontend/src/components/ui/SkillNode.jsx
@@ -100,19 +100,33 @@ export default function SkillNode({ id, data }) {
           Tu travailles ici
         </div>
       )}
-      {isLocked && !isNext && !isCroissance && (
+      {isLocked && (
         <div
-          className="absolute -top-7 chip whitespace-nowrap z-10 !text-[10px] opacity-0 group-hover:opacity-100 transition-opacity duration-200 pointer-events-none"
-          role="tooltip"
+          className="absolute top-1.5 right-1.5 z-20 w-5 h-5 rounded-full bg-paper border border-sage/25 flex items-center justify-center text-stem pointer-events-none"
+          aria-label="Compétence verrouillée"
+          title="Pas encore accessible — touche pour voir les racines manquantes"
         >
-          Pas encore accessible
+          <svg
+            width="10"
+            height="10"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.4"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <rect x="4" y="11" width="16" height="10" rx="2" />
+            <path d="M8 11V7a4 4 0 0 1 8 0v4" />
+          </svg>
         </div>
       )}
       {isPrereqOfHover && (
         <div className="absolute inset-0 rounded-[0.875rem] pointer-events-none prereq-glow z-0" />
       )}
       <div
-        className={`specimen relative w-full px-3 pt-3 pb-2.5 transition-transform duration-200 origin-center group-hover:scale-[1.06] group-hover:z-10 ${isCroissance ? "specimen-croissance" : ""} ${isLocked ? "cursor-help" : "cursor-pointer"}`}
+        className={`specimen relative w-full px-3 pt-3 pb-2.5 transition-transform duration-200 origin-center group-hover:scale-[1.06] group-hover:z-10 cursor-pointer ${isCroissance ? "specimen-croissance" : ""}`}
         style={cardStyle}
       >
         <div


### PR DESCRIPTION
## Summary
- Fixes #121. Header restructured for <sm: grade picker collapses to a `<select>`, search input is `w-full sm:w-64 max-w-full`, no horizontal overflow at 375/834/1440.
- Below `md`, ReactFlow is replaced by a `<SkillListView>` fallback — skills grouped by year, tap to open the detail panel.
- Locked skills now show an always-visible lock badge (no hover dependency) and the detail panel lists the specific unmastered prerequisites.
- Keyboard nav on md+: arrow keys move focus between nodes with a pan-to-focus, Enter opens the detail panel.
- Status legend moved to top-left so it can't overlap the bottom-right `<Controls>`.

## Test plan
- [x] `npm run lint` passes
- [x] `npm run build` passes
- [x] New `e2e/skilltree-mobile.spec.js` smokes 375 / 834 / 1440 (no horizontal overflow, header items visible, list-view + keyboard nav exercised)
- [ ] Manual QA at 375px: pick a grade from the `<select>`, tap a locked skill, confirm the panel shows the missing roots
- [ ] Manual QA at 1440px: click the flow, arrow-key across nodes, press Enter to open the detail panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)