### PR TITLE
Hide Django /admin/ + fail2ban jail for auth brute-force

### DIFF
--- a/.claude/skills/prod-ops/SKILL.md
+++ b/.claude/skills/prod-ops/SKILL.md
@@ -130,6 +130,15 @@ Mental checklist, in order:
 4. **Recent deploy?** — `gh run list --workflow=deploy.yml --limit 5`. If a deploy landed just before the incident, correlate.
 5. **Logs** — `docker logs pedagogia-backend-1 --tail=200` for Django, `pedagogia-frontend-1` for Caddy, `pedagogia-db-1` for Postgres.
 
+## Admin + auth hardening
+
+- **Admin URL** — `/admin/` returns 404 in prod. The real admin lives at `DJANGO_ADMIN_PATH` from `.env.prod` (a random slug like `mgmt-<token>/`). If you forget it: `ssh pedagogia@46.225.142.212 'grep DJANGO_ADMIN_PATH /opt/pedagogia/.env.prod'`. To rotate, edit `.env.prod` and restart `backend` (see step 10 of `prod/bootstrap.md`).
+- **fail2ban** — a host jail tails Caddy's JSON access log (bind-mounted at `/var/log/pedagogia-caddy/access.log`) and bans via iptables after 10 failed 401/403 hits on `/api/auth/login` or `/api/auth/registration` in 10 min, for 1 h. Real client IP is extracted from the `CF-Connecting-IP` header (Caddy's TCP peer is always a Cloudflare edge).
+  - Status: `sudo fail2ban-client status pedagogia-auth`
+  - Unban one: `sudo fail2ban-client unban <ip>`
+  - Unban all: `sudo fail2ban-client unban --all`
+  - Config source of truth: `prod/fail2ban/` in the repo. After editing, re-run `sudo ./install-fail2ban.sh` on the server (idempotent).
+
 ## Things that require explicit user confirmation
 
 Production is shared state with real users. Never do any of these without an explicit ack in the current conversation:

--- a/backend/pedagogia/urls.py
+++ b/backend/pedagogia/urls.py
@@ -1,3 +1,5 @@
+import os
+
 from django.contrib import admin
 from django.http import HttpResponse, JsonResponse
 from django.middleware.csrf import get_token
@@ -13,6 +15,13 @@ from apps.accounts.views import (
     UserDetailsView,
 )
 
+# In prod we mount the admin under a random slug so the default /admin/ 404s —
+# a stolen superuser cookie is a big deal and hiding the URL raises the bar.
+# Default stays "admin/" so local dev is unchanged.
+_admin_path = os.environ.get("DJANGO_ADMIN_PATH", "admin/")
+if not _admin_path.endswith("/"):
+    _admin_path = f"{_admin_path}/"
+
 
 @ensure_csrf_cookie
 def csrf(request):
@@ -25,7 +34,7 @@ def health(_request):
 
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path(_admin_path, admin.site.urls),
     path("api/health/", health),
     path("api/csrf/", csrf),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),

--- a/backend/tests/test_admin_url.py
+++ b/backend/tests/test_admin_url.py
@@ -1,0 +1,43 @@
+import importlib
+
+from django.test import Client
+from django.urls import clear_url_caches
+
+
+def _reload_urls(settings):
+    clear_url_caches()
+    importlib.reload(importlib.import_module(settings.ROOT_URLCONF))
+
+
+def test_admin_defaults_to_standard_path(db, settings, monkeypatch):
+    monkeypatch.delenv("DJANGO_ADMIN_PATH", raising=False)
+    _reload_urls(settings)
+    try:
+        response = Client().get("/admin/", follow=False)
+        assert response.status_code in (301, 302)
+    finally:
+        _reload_urls(settings)
+
+
+def test_admin_moves_when_env_is_set(db, settings, monkeypatch):
+    monkeypatch.setenv("DJANGO_ADMIN_PATH", "hidden-console/")
+    _reload_urls(settings)
+    try:
+        client = Client()
+        assert client.get("/admin/", follow=False).status_code == 404
+        response = client.get("/hidden-console/", follow=False)
+        assert response.status_code in (301, 302)
+    finally:
+        monkeypatch.delenv("DJANGO_ADMIN_PATH", raising=False)
+        _reload_urls(settings)
+
+
+def test_admin_env_tolerates_missing_trailing_slash(db, settings, monkeypatch):
+    monkeypatch.setenv("DJANGO_ADMIN_PATH", "mgmt-xyz")
+    _reload_urls(settings)
+    try:
+        response = Client().get("/mgmt-xyz/", follow=False)
+        assert response.status_code in (301, 302)
+    finally:
+        monkeypatch.delenv("DJANGO_ADMIN_PATH", raising=False)
+        _reload_urls(settings)

--- a/prod/.env.prod.example
+++ b/prod/.env.prod.example
@@ -18,6 +18,10 @@ DJANGO_ALLOWED_HOSTS=collegia.be,www.collegia.be,localhost
 CORS_ORIGINS=https://collegia.be,https://www.collegia.be
 CSRF_TRUSTED_ORIGINS=https://collegia.be,https://www.collegia.be
 GUNICORN_WORKERS=3
+# Admin is mounted at this path. Generate a random slug so /admin/ 404s:
+#   python3 -c "import secrets; print('mgmt-' + secrets.token_urlsafe(12))"
+# Must end with a slash (urls.py normalises it if missing). Default in dev: admin/
+DJANGO_ADMIN_PATH=admin/
 
 # ===== Anthropic (Claude API) =====
 ANTHROPIC_API_KEY=

--- a/prod/Caddyfile
+++ b/prod/Caddyfile
@@ -31,7 +31,11 @@
 	}
 
 	log {
-		output stdout
+		output file /var/log/caddy/access.log {
+			roll_size 10mb
+			roll_keep 5
+			roll_keep_for 168h
+		}
 		format json
 	}
 }

--- a/prod/bootstrap.md
+++ b/prod/bootstrap.md
@@ -35,6 +35,9 @@ python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 
 # Postgres password
 openssl rand -base64 32
+
+# Random slug for DJANGO_ADMIN_PATH (hides /admin/ — see step 10)
+python3 -c "import secrets; print('mgmt-' + secrets.token_urlsafe(12) + '/')"
 ```
 
 ## 3. GHCR image visibility
@@ -130,3 +133,75 @@ cd /tmp && curl -fsSL https://github.com/FiloSottile/age/releases/download/v1.2.
 ```
 
 Age private key is **not** stored on the VPS — it lives in 1Password ("collegia — storage box + backup keys"). Losing it means the existing dumps become unrecoverable. Losing the VPS does not affect dumps; losing Hetzner Falkenstein does not affect the server.
+
+## 10. Hide the Django admin behind a random slug
+
+`DJANGO_ADMIN_PATH` in `.env.prod` controls where the admin is mounted. Set it to a random slug — the default `/admin/` then 404s for anyone fishing:
+
+```bash
+# Already generated in step 2 if you followed along; otherwise:
+python3 -c "import secrets; print('mgmt-' + secrets.token_urlsafe(12) + '/')"
+```
+
+Update the value in `/opt/pedagogia/.env.prod`, then `docker compose up -d backend` to restart. Bookmark the new URL locally — it's only in `.env.prod`, not in any code. If you ever forget it, SSH in and `grep DJANGO_ADMIN_PATH /opt/pedagogia/.env.prod`.
+
+Verify:
+
+```bash
+curl -o /dev/null -s -w "%{http_code}\n" https://collegia.be/admin/
+# 404
+curl -o /dev/null -s -w "%{http_code}\n" https://collegia.be/mgmt-<slug>/
+# 302 — redirect to login
+```
+
+## 11. fail2ban for auth brute-force
+
+Caddy writes JSON access logs to `/var/log/pedagogia-caddy/access.log` on the host (bind mount in `docker-compose.prod.yml`). A fail2ban jail tails that file, extracts the real client IP from the `CF-Connecting-IP` header, and bans after repeated 401/403 on `/api/auth/login` or `/api/auth/registration`.
+
+First time on a new VPS:
+
+```bash
+cd /opt/pedagogia
+sudo ./install-fail2ban.sh
+```
+
+That installs the `fail2ban` package if missing, copies `prod/fail2ban/filter.d/pedagogia-auth.conf` and `prod/fail2ban/jail.d/pedagogia-auth.conf` into `/etc/fail2ban/`, and restarts the service. The jail: **10 failed auth hits in 10 minutes → 1-hour ban at iptables level**.
+
+The installer is idempotent — re-run it after editing the configs in the repo.
+
+Verify:
+
+```bash
+sudo fail2ban-client status pedagogia-auth
+# Status for the jail: pedagogia-auth
+# |- Filter
+# |  |- Currently failed: 0
+# |  |- Total failed:     0
+# |  `- File list:        /var/log/pedagogia-caddy/access.log
+# `- Actions
+#    |- Currently banned: 0
+#    ...
+```
+
+End-to-end check (from the laptop, deliberately miss 11 times):
+
+```bash
+for i in $(seq 1 11); do
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -X POST https://collegia.be/api/auth/login/ \
+    -H 'Content-Type: application/json' \
+    -d '{"email":"nobody@example.com","password":"wrong"}'
+done
+# Expect 401 × 10 then connection refused / timeout on the 12th (banned at L3).
+```
+
+**Unbanning a locked-out user** (they called, it was a password reset typo spiral):
+
+```bash
+sudo fail2ban-client status pedagogia-auth         # find the banned IP
+sudo fail2ban-client unban <ip>
+# Or wipe the whole jail:
+sudo fail2ban-client unban --all
+```
+
+**Caveat** — all TCP connections to the origin come from Cloudflare IPs (Hetzner firewall drops everything else, per step 8). The real attacker is banned *via the CF-Connecting-IP header*, so if Cloudflare isn't in front, or the header is missing, the filter won't match. That's fine for the current architecture; revisit if we ever expose the origin directly.

--- a/prod/docker-compose.prod.yml
+++ b/prod/docker-compose.prod.yml
@@ -60,6 +60,8 @@ services:
     volumes:
       - caddy_data:/data
       - caddy_config:/config
+      # Access log on the host so fail2ban can tail it.
+      - /var/log/pedagogia-caddy:/var/log/caddy
     depends_on:
       backend:
         condition: service_healthy

--- a/prod/fail2ban/filter.d/pedagogia-auth.conf
+++ b/prod/fail2ban/filter.d/pedagogia-auth.conf
@@ -1,0 +1,14 @@
+# fail2ban filter for PedagogIA: repeated 401/403 on /api/auth/login|registration
+#
+# Parses Caddy JSON access logs (one JSON object per line) and extracts the
+# real client IP from the Cf-Connecting-Ip header, since Caddy's TCP peer is
+# always a Cloudflare edge (the Hetzner firewall drops everything else — see
+# prod/hetzner-firewall.sh). Banning the Caddy peer IP would ban Cloudflare.
+#
+# Field order inside the JSON is not guaranteed, so the three conditions are
+# expressed as lookaheads. The actual IP capture uses <HOST>, which fail2ban
+# replaces with its standard IP-address regex.
+[Definition]
+failregex = ^(?=.*"uri":"/api/auth/(?:login|registration)(?:/[^"]*)?")(?=.*"status":(?:401|403))(?=.*"Cf-Connecting-Ip":\["<HOST>"\]).*$
+ignoreregex =
+datepattern = "ts":(?:\d+\.\d+|\d+)

--- a/prod/fail2ban/jail.d/pedagogia-auth.conf
+++ b/prod/fail2ban/jail.d/pedagogia-auth.conf
@@ -1,0 +1,15 @@
+# PedagogIA auth brute-force jail.
+#
+# 10 failed auth hits (401/403 on /api/auth/login or /api/auth/registration)
+# within 10 minutes from the same real client IP → ban for 1 hour at the host
+# iptables level. Complements DRF throttling (app-level 429) and Cloudflare
+# edge rules — this one drops packets so Gunicorn doesn't even see them.
+[pedagogia-auth]
+enabled  = true
+filter   = pedagogia-auth
+logpath  = /var/log/pedagogia-caddy/access.log
+backend  = auto
+maxretry = 10
+findtime = 600
+bantime  = 3600
+action   = iptables-multiport[name=pedagogia-auth, port="http,https", protocol=tcp]

--- a/prod/install-fail2ban.sh
+++ b/prod/install-fail2ban.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Install / refresh the PedagogIA fail2ban jail on the VPS.
+#
+# Idempotent: safe to re-run after config changes. Copies the filter + jail
+# files from this repo to /etc/fail2ban/, ensures the Caddy log dir exists
+# and is readable, then restarts fail2ban and prints the jail status.
+#
+# Run as root on the server:
+#   sudo ./install-fail2ban.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FILTER_SRC="$SCRIPT_DIR/fail2ban/filter.d/pedagogia-auth.conf"
+JAIL_SRC="$SCRIPT_DIR/fail2ban/jail.d/pedagogia-auth.conf"
+
+if [[ $EUID -ne 0 ]]; then
+  echo "Must run as root (needs to write /etc/fail2ban and restart the service)." >&2
+  exit 1
+fi
+
+if ! command -v fail2ban-client >/dev/null 2>&1; then
+  echo "Installing fail2ban..."
+  apt-get update -y
+  apt-get install -y fail2ban
+fi
+
+mkdir -p /var/log/pedagogia-caddy
+# Caddy runs as root inside its container so the bind mount is writable by
+# default; nothing to chown here. fail2ban runs as root too, so it can read.
+
+install -m 0644 "$FILTER_SRC" /etc/fail2ban/filter.d/pedagogia-auth.conf
+install -m 0644 "$JAIL_SRC"   /etc/fail2ban/jail.d/pedagogia-auth.conf
+
+systemctl enable fail2ban
+systemctl restart fail2ban
+
+sleep 1
+fail2ban-client status pedagogia-auth


### PR DESCRIPTION
Closes #100, closes #101.

## Summary
- **#100** — Admin URL is no longer `/admin/`. `pedagogia/urls.py` reads `DJANGO_ADMIN_PATH` (default `admin/` in dev, random slug in prod). Default `/admin/` 404s when the env var points elsewhere.
- **#101** — Caddy writes JSON access logs to a host-mounted file (`/var/log/pedagogia-caddy/access.log`). A fail2ban jail tails it and bans after 10 × 401/403 on `/api/auth/(login|registration)` in 10 min, for 1 h, via `iptables-multiport`. Real client IP is extracted from the `CF-Connecting-IP` header.
- Includes an idempotent installer (`prod/install-fail2ban.sh`), bootstrap docs (steps 10 + 11), and an unban runbook in the `prod-ops` skill.

## Test plan
- [x] `uv run pytest` — 147 passed, including 3 new tests covering the admin URL behaviour (default, env-overridden, missing trailing slash).
- [x] `ruff check` clean on the touched files.
- [x] `caddy validate` passes on the updated Caddyfile.
- [ ] On the VPS after merge: update `DJANGO_ADMIN_PATH` in `.env.prod`, redeploy backend, confirm `curl https://collegia.be/admin/` returns 404 and the slug URL redirects to login.
- [ ] On the VPS after merge: `sudo /opt/pedagogia/install-fail2ban.sh`, then run the 11-bad-logins loop from `bootstrap.md` step 11 — 12th request should be refused at L3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)