### PR TITLE
feat(#135, #136, #137): UX-audit follow-up sweep

### DIFF
--- a/frontend/e2e/auth.spec.js
+++ b/frontend/e2e/auth.spec.js
@@ -17,6 +17,7 @@ test("full auth + child flow", async ({ page }) => {
   await page.getByTestId("register-name").fill("Alice")
   await page.getByTestId("register-email").fill(email)
   await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-password-confirm").fill("SuperStrong!23")
   await page.getByTestId("register-submit").click()
 
   await expect(page).toHaveURL(/\/children/)

--- a/frontend/e2e/exercise.spec.js
+++ b/frontend/e2e/exercise.spec.js
@@ -12,6 +12,7 @@ test("training flow: register → home → exercise → wrong → feedback → s
   await page.getByTestId("register-name").fill("Alice")
   await page.getByTestId("register-email").fill(email)
   await page.getByTestId("register-password").fill(password)
+  await page.getByTestId("register-password-confirm").fill(password)
   await page.getByTestId("register-submit").click()
   await expect(page).toHaveURL(/\/children/)
 

--- a/frontend/e2e/parent-dashboard.spec.js
+++ b/frontend/e2e/parent-dashboard.spec.js
@@ -11,6 +11,7 @@ test("parent can open /dashboard and see their children", async ({ page }) => {
   await page.getByTestId("register-name").fill("Marie")
   await page.getByTestId("register-email").fill(email)
   await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-password-confirm").fill("SuperStrong!23")
   await page.getByTestId("register-submit").click()
   await expect(page).toHaveURL(/\/children/)
 

--- a/frontend/e2e/skilltree-mobile.spec.js
+++ b/frontend/e2e/skilltree-mobile.spec.js
@@ -12,6 +12,7 @@ async function signUpAndPickChild(page) {
   await page.getByTestId("register-name").fill("Camille")
   await page.getByTestId("register-email").fill(email)
   await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-password-confirm").fill("SuperStrong!23")
   await page.getByTestId("register-submit").click()
   await expect(page).toHaveURL(/\/children/)
 

--- a/frontend/e2e/skilltree-preview.spec.js
+++ b/frontend/e2e/skilltree-preview.spec.js
@@ -12,6 +12,7 @@ test("skill tree page renders for a logged-in student", async ({ page }) => {
   await page.getByTestId("register-name").fill("Camille")
   await page.getByTestId("register-email").fill(email)
   await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-password-confirm").fill("SuperStrong!23")
   await page.getByTestId("register-submit").click()
   await expect(page).toHaveURL(/\/children/)
 

--- a/frontend/e2e/ux-audit.spec.js
+++ b/frontend/e2e/ux-audit.spec.js
@@ -1,0 +1,61 @@
+import { test, expect } from "@playwright/test"
+
+test("login inputs are ≥16px at 375px so iOS never auto-zooms on focus", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto("/login")
+
+  for (const tid of ["login-email", "login-password"]) {
+    const fontSize = await page
+      .getByTestId(tid)
+      .evaluate((el) => parseFloat(getComputedStyle(el).fontSize))
+    expect(fontSize).toBeGreaterThanOrEqual(16)
+  }
+})
+
+test("register inputs are ≥16px at 375px and have autocomplete + inputmode", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto("/register")
+
+  const fields = [
+    { tid: "register-email", autoComplete: "email", inputMode: "email" },
+    { tid: "register-password", autoComplete: "new-password" },
+    { tid: "register-password-confirm", autoComplete: "new-password" },
+  ]
+  for (const f of fields) {
+    const input = page.getByTestId(f.tid)
+    const fontSize = await input.evaluate((el) =>
+      parseFloat(getComputedStyle(el).fontSize)
+    )
+    expect(fontSize).toBeGreaterThanOrEqual(16)
+    await expect(input).toHaveAttribute("autocomplete", f.autoComplete)
+    if (f.inputMode) await expect(input).toHaveAttribute("inputmode", f.inputMode)
+  }
+})
+
+test("register: confirm-password mismatch disables submit and shows a message", async ({ page }) => {
+  await page.goto("/register")
+
+  await page.getByTestId("register-email").fill(`mismatch-${Date.now()}@example.com`)
+  await page.getByTestId("register-password").fill("SuperStrong!23")
+  await page.getByTestId("register-password-confirm").fill("SuperStrong!ZZ")
+
+  await expect(page.getByTestId("register-password-mismatch")).toBeVisible()
+  await expect(page.getByTestId("register-submit")).toBeDisabled()
+
+  await page.getByTestId("register-password-confirm").fill("SuperStrong!23")
+  await expect(page.getByTestId("register-password-mismatch")).toHaveCount(0)
+  await expect(page.getByTestId("register-submit")).toBeEnabled()
+})
+
+test("login error is announced with aria-live=polite", async ({ page }) => {
+  await page.setViewportSize({ width: 375, height: 812 })
+  await page.goto("/login")
+
+  await page.getByTestId("login-email").fill(`nobody-${Date.now()}@example.com`)
+  await page.getByTestId("login-password").fill("WrongPassword!1")
+  await page.getByTestId("login-submit").click()
+
+  const err = page.getByTestId("login-error")
+  await expect(err).toBeVisible({ timeout: 10000 })
+  await expect(err).toHaveAttribute("aria-live", "polite")
+})

--- a/frontend/src/components/exercises/ExerciseCard.jsx
+++ b/frontend/src/components/exercises/ExerciseCard.jsx
@@ -65,7 +65,7 @@ export default function ExerciseCard({
           <p className="font-display text-sm text-bark mt-0.5 mb-5">{skill.label}</p>
         </>
       )}
-      <div className="font-mono text-4xl md:text-5xl font-semibold text-bark mb-5 tabular-nums tracking-tight text-balance">
+      <div className="font-mono text-3xl sm:text-4xl md:text-5xl font-semibold text-bark mb-5 tabular-nums tracking-tight text-balance break-words">
         {prompt}
       </div>
 

--- a/frontend/src/components/exercises/NumberPad.jsx
+++ b/frontend/src/components/exercises/NumberPad.jsx
@@ -18,6 +18,8 @@ export default function NumberPad({ value, onChange, onSubmit, disabled }) {
 
   const digitClass =
     "specimen bg-bone hover:bg-mist active:bg-sage-leaf/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-deep text-bark font-mono text-3xl font-semibold py-5 min-h-[3.75rem] rounded-xl cursor-pointer transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:hover:translate-y-0 tabular-nums"
+  const commaClass =
+    "specimen bg-sky-soft hover:bg-sky/40 active:bg-sky/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-deep text-sky-deep font-mono text-3xl font-semibold py-5 min-h-[3.75rem] rounded-xl cursor-pointer transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:hover:translate-y-0 flex flex-col items-center justify-center leading-none"
   const utilClass =
     "specimen bg-paper hover:bg-mist active:bg-sage-leaf/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-deep text-bark font-mono text-2xl py-5 min-h-[3.75rem] min-w-11 rounded-xl cursor-pointer flex items-center justify-center transition-transform hover:-translate-y-0.5 active:translate-y-0 disabled:opacity-50 disabled:hover:translate-y-0"
 
@@ -43,7 +45,7 @@ export default function NumberPad({ value, onChange, onSubmit, disabled }) {
         className={utilClass}
         aria-label="Effacer le dernier chiffre"
       >
-        <Icon name="backspace" />
+        <Icon name="backspace" size={28} />
       </button>
       <button
         type="button"
@@ -59,10 +61,13 @@ export default function NumberPad({ value, onChange, onSubmit, disabled }) {
         onClick={() => press(",")}
         disabled={disabled || value.includes(",")}
         data-testid="number-pad-key-comma"
-        className={digitClass}
+        className={commaClass}
         aria-label="Virgule décimale"
       >
-        ,
+        <span aria-hidden="true">,</span>
+        <span className="text-[9px] uppercase tracking-widest font-sans font-semibold mt-1 opacity-80">
+          virgule
+        </span>
       </button>
       <button
         type="button"

--- a/frontend/src/components/screens/ChildPickerScreen.jsx
+++ b/frontend/src/components/screens/ChildPickerScreen.jsx
@@ -126,6 +126,8 @@ export default function ChildPickerScreen() {
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Prénom"
+                autoComplete="given-name"
+                inputMode="text"
                 className="flex-1"
                 data-testid="child-name"
               />

--- a/frontend/src/components/screens/DiagnosticResult.jsx
+++ b/frontend/src/components/screens/DiagnosticResult.jsx
@@ -72,8 +72,15 @@ function VerdictHero({ verdict, child, overallPct, totalCorrect, totalAttempts }
       <div className="absolute -bottom-20 -left-20 w-56 h-56 rounded-full bg-sky/20 blur-3xl pointer-events-none" />
 
       <div className="relative flex flex-col md:flex-row items-center gap-6">
-        <div className="relative shrink-0">
-          <svg width="140" height="140" viewBox="0 0 140 140" className="-rotate-90">
+        <div
+          className="relative shrink-0"
+          style={{ width: "clamp(96px, 26vw, 140px)", height: "clamp(96px, 26vw, 140px)" }}
+        >
+          <svg
+            viewBox="0 0 140 140"
+            preserveAspectRatio="xMidYMid meet"
+            className="-rotate-90 w-full h-full"
+          >
             <circle
               cx="70" cy="70" r="54"
               className="fill-none stroke-mist"
@@ -89,7 +96,7 @@ function VerdictHero({ verdict, child, overallPct, totalCorrect, totalAttempts }
             />
           </svg>
           <div className="absolute inset-0 flex flex-col items-center justify-center">
-            <div className="font-display font-semibold text-5xl text-bark tabular-nums leading-none">
+            <div className="font-display font-semibold text-4xl sm:text-5xl text-bark tabular-nums leading-none">
               {hasLevel ? verdict.level : "—"}
             </div>
             {hasLevel && (
@@ -248,7 +255,7 @@ export default function DiagnosticResult({
         />
 
         <div
-          className={`grid grid-cols-3 gap-3 mb-8 transition-all duration-500 delay-200 ${
+          className={`grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 mb-8 transition-all duration-500 delay-200 ${
             contentMounted ? "opacity-100 translate-y-0" : "opacity-0 translate-y-1"
           }`}
           data-testid="diagnostic-counts"

--- a/frontend/src/components/screens/DiagnosticScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticScreen.jsx
@@ -1,9 +1,10 @@
-import { useEffect } from "react"
+import { useEffect, useState } from "react"
 import { useNavigate } from "react-router"
 import AppShell from "../layout/AppShell"
 import TopBar from "../layout/TopBar"
 import { TopBarBack } from "../layout/TopBarActions"
 import ProgressBar from "../ui/ProgressBar"
+import ConfirmDialog from "../ui/ConfirmDialog"
 import ExerciseCard from "../exercises/ExerciseCard"
 import LevelGauge from "../exercises/LevelGauge"
 import { useDiagnosticStore } from "../../stores/diagnosticStore"
@@ -18,6 +19,7 @@ export default function DiagnosticScreen() {
     start, submit, loadNext, reset,
   } = useDiagnosticStore()
   const child = children.find((c) => c.id === selectedChildId)
+  const [confirmQuit, setConfirmQuit] = useState(false)
 
   useEffect(() => {
     if (!selectedChildId) {
@@ -27,14 +29,19 @@ export default function DiagnosticScreen() {
     if (!sessionId && !done) start(selectedChildId)
   }, [selectedChildId, sessionId, done, start, navigate])
 
-  const handleQuit = async () => {
+  const leaveNow = async () => {
     reset()
     await bootstrap()
     navigate("/")
   }
 
+  const handleQuit = () => {
+    if (done) return leaveNow()
+    setConfirmQuit(true)
+  }
+
   if (done && result) {
-    return <DiagnosticResult result={result} child={child} onBack={handleQuit} />
+    return <DiagnosticResult result={result} child={child} onBack={leaveNow} />
   }
 
   const progress = current ? current.index + 1 : 0
@@ -74,8 +81,8 @@ export default function DiagnosticScreen() {
           </div>
         )}
 
-        <div className="relative w-full flex justify-center">
-          <div className="w-full max-w-xl">
+        <div className="w-full flex flex-col lg:flex-row lg:items-start lg:justify-center gap-6 lg:gap-8">
+          <div className="w-full max-w-xl mx-auto lg:mx-0">
             <ExerciseCard
               key={current?.exercise?.signature || "loading"}
               exercise={current?.exercise}
@@ -89,7 +96,7 @@ export default function DiagnosticScreen() {
             />
           </div>
           {current && (
-            <div className="hidden lg:block absolute right-6 top-2">
+            <div className="hidden lg:block shrink-0 pt-2">
               <LevelGauge
                 grade={current?.cursor?.grade || current?.skill?.grade}
                 difficulty={current?.cursor?.difficulty || current?.difficulty}
@@ -98,6 +105,20 @@ export default function DiagnosticScreen() {
           )}
         </div>
       </div>
+
+      <ConfirmDialog
+        open={confirmQuit}
+        latin="Hortum relinquere"
+        title="Quitter le test ?"
+        message="Tes réponses seront perdues si tu quittes avant la fin."
+        confirmLabel="Quitter"
+        cancelLabel="Continuer"
+        onConfirm={() => {
+          setConfirmQuit(false)
+          leaveNow()
+        }}
+        onCancel={() => setConfirmQuit(false)}
+      />
     </AppShell>
   )
 }

--- a/frontend/src/components/screens/DrillScreen.jsx
+++ b/frontend/src/components/screens/DrillScreen.jsx
@@ -93,6 +93,19 @@ export default function DrillScreen() {
       <div className="flex-1 flex flex-col items-center px-5 sm:px-6 py-6 sm:py-8">
         {current && (
           <div className="w-full max-w-xl mb-4" data-testid="drill-progress">
+            {current.skill && (
+              <div
+                className="flex flex-wrap items-center gap-2 mb-2"
+                data-testid="drill-skill-context"
+              >
+                <Chip tone="sage" className="!text-[10px]">
+                  {current.skill.grade} · {current.skill.label}
+                </Chip>
+                <Chip tone="sky" className="!text-[10px]">
+                  {Math.max(total - progress + 1, 0)} restantes
+                </Chip>
+              </div>
+            )}
             <div className="flex justify-between items-center mb-1.5">
               <span className="text-xs text-stem font-mono">
                 Question {progress} / {total}

--- a/frontend/src/components/screens/RegisterScreen.jsx
+++ b/frontend/src/components/screens/RegisterScreen.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import { Link, useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
 import AppShell from "../layout/AppShell"
@@ -7,17 +7,44 @@ import Card from "../ui/Card"
 import Input from "../ui/Input"
 import { Heading, LatinLabel } from "../ui/Heading"
 
+function scorePassword(pw) {
+  if (!pw) return 0
+  let s = 0
+  if (pw.length >= 8) s += 1
+  if (pw.length >= 12) s += 1
+  if (/[A-Z]/.test(pw) && /[a-z]/.test(pw)) s += 1
+  if (/\d/.test(pw)) s += 1
+  if (/[^A-Za-z0-9]/.test(pw)) s += 1
+  return Math.min(s, 4)
+}
+
+const STRENGTH = [
+  { label: "Trop court", tone: "bg-rose text-rose" },
+  { label: "Faible", tone: "bg-rose text-rose" },
+  { label: "Correct", tone: "bg-honey text-honey" },
+  { label: "Bon", tone: "bg-sage text-sage-deep" },
+  { label: "Solide", tone: "bg-sage-deep text-sage-deep" },
+]
+
 export default function RegisterScreen() {
   const register = useAuthStore((s) => s.register)
   const navigate = useNavigate()
   const [email, setEmail] = useState("")
   const [password, setPassword] = useState("")
+  const [confirm, setConfirm] = useState("")
   const [displayName, setDisplayName] = useState("")
   const [error, setError] = useState(null)
   const [busy, setBusy] = useState(false)
 
+  const score = useMemo(() => scorePassword(password), [password])
+  const mismatch = confirm.length > 0 && confirm !== password
+
   const onSubmit = async (e) => {
     e.preventDefault()
+    if (mismatch) {
+      setError("Les mots de passe ne correspondent pas.")
+      return
+    }
     setBusy(true)
     setError(null)
     try {
@@ -30,6 +57,8 @@ export default function RegisterScreen() {
       setBusy(false)
     }
   }
+
+  const strength = STRENGTH[score]
 
   return (
     <AppShell surface="greenhouse">
@@ -50,6 +79,7 @@ export default function RegisterScreen() {
               value={displayName}
               onChange={(e) => setDisplayName(e.target.value)}
               autoComplete="given-name"
+              inputMode="text"
               className="mt-1"
               data-testid="register-name"
             />
@@ -81,6 +111,48 @@ export default function RegisterScreen() {
               className="mt-1"
               data-testid="register-password"
             />
+            {password && (
+              <div
+                className="mt-2 flex items-center gap-2"
+                data-testid="register-strength"
+                aria-live="polite"
+              >
+                <div className="flex-1 h-1.5 rounded-full bg-mist overflow-hidden">
+                  <div
+                    className={`h-full transition-all duration-300 ${strength.tone.split(" ")[0]}`}
+                    style={{ width: `${(score / 4) * 100}%` }}
+                  />
+                </div>
+                <span className={`text-xs font-semibold ${strength.tone.split(" ")[1]}`}>
+                  {strength.label}
+                </span>
+              </div>
+            )}
+          </label>
+
+          <label className="block">
+            <span className="text-sm font-medium text-bark">Confirmer le mot de passe</span>
+            <Input
+              type="password"
+              required
+              minLength={8}
+              autoComplete="new-password"
+              value={confirm}
+              onChange={(e) => setConfirm(e.target.value)}
+              className="mt-1"
+              data-testid="register-password-confirm"
+              aria-invalid={mismatch}
+            />
+            {mismatch && (
+              <p
+                className="mt-1 text-xs text-rose"
+                data-testid="register-password-mismatch"
+                role="alert"
+                aria-live="polite"
+              >
+                Les deux mots de passe doivent être identiques.
+              </p>
+            )}
           </label>
 
           {error && (
@@ -94,7 +166,12 @@ export default function RegisterScreen() {
             </p>
           )}
 
-          <Button type="submit" disabled={busy} className="w-full" data-testid="register-submit">
+          <Button
+            type="submit"
+            disabled={busy || mismatch}
+            className="w-full"
+            data-testid="register-submit"
+          >
             {busy ? "Création…" : "Créer le compte"}
           </Button>
 

--- a/frontend/src/components/ui/ConfirmDialog.jsx
+++ b/frontend/src/components/ui/ConfirmDialog.jsx
@@ -1,0 +1,73 @@
+import { useEffect } from "react"
+import Button from "./Button"
+import Card from "./Card"
+import { Heading, LatinLabel } from "./Heading"
+
+export default function ConfirmDialog({
+  open,
+  title = "Confirmer",
+  latin,
+  message,
+  confirmLabel = "Confirmer",
+  cancelLabel = "Annuler",
+  onConfirm,
+  onCancel,
+}) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault()
+        onCancel?.()
+      } else if (e.key === "Enter") {
+        e.preventDefault()
+        onConfirm?.()
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [open, onConfirm, onCancel])
+
+  if (!open) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-5 bg-bark/30 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirm-dialog-title"
+      onClick={onCancel}
+      data-testid="confirm-dialog"
+    >
+      <Card
+        className="p-6 sm:p-7 max-w-sm w-full text-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {latin && <LatinLabel>{latin}</LatinLabel>}
+        <Heading level={3} className="mt-1" id="confirm-dialog-title">
+          {title}
+        </Heading>
+        {message && <p className="text-sm text-stem mt-3">{message}</p>}
+        <div className="mt-6 flex flex-col sm:flex-row gap-2 sm:gap-3">
+          <Button
+            variant="ghost"
+            onClick={onCancel}
+            className="flex-1"
+            data-testid="confirm-dialog-cancel"
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            variant="primary"
+            onClick={onConfirm}
+            autoFocus
+            className="flex-1"
+            data-testid="confirm-dialog-confirm"
+          >
+            {confirmLabel}
+          </Button>
+        </div>
+      </Card>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
One bundled pass across the three screens flagged by the 2026-04-18 UX audit (auth/ChildPicker forms, Diagnostic + DiagnosticResult, Drill + Exercise), so they move together and share a single regression check. Closes #135, closes #136, closes #137.

### #135 — touch-friendly form inputs
- Register gains a **confirm-password** field with `autocomplete=\"new-password\"`, a minimal strength hint, a mismatch message (`aria-live=\"polite\"`), and a submit that disables on mismatch.
- ChildPicker quick-add input picks up `autocomplete=\"given-name\"` / `inputmode=\"text\"`.
- 16 px input baseline was already in \`src/index.css\`, so iOS Safari no longer zooms on focus — confirmed by a new 375 px smoke.

### #136 — Diagnostic + DiagnosticResult polish
- LevelGauge now sits next to the exercise card in a flex row at `lg+` instead of floating in the right gutter.
- \"Quitter\" opens a new reusable \`ConfirmDialog\` (Enter confirms, Esc cancels, click-outside cancels).
- DiagnosticResult verdict ring switches to \`viewBox\` + \`clamp()\` sizing, and the count cards stack **3 → 2 → 1** from desktop down to 320 px via \`grid-cols-1 sm:grid-cols-2 md:grid-cols-3\`.

### #137 — Drill + Exercise micro-UX
- NumberPad: comma key gets a sky tint + \"virgule\" sublabel so it reads as distinct from \`0\`; backspace icon bumped to 28 px.
- Drill entry shows a skill + remaining-questions chip near the title (no silent drop-in).
- Exercise question text steps down to \`text-3xl sm:text-4xl md:text-5xl\` with \`break-words\` so short equations don't orphan-wrap at 375 px.

### Tests
- New \`frontend/e2e/ux-audit.spec.js\`: 375 px font-size smoke (Login + Register), autocomplete/inputmode assertions, register mismatch flow, Login \`aria-live\` error.
- Existing specs (\`auth\`, \`exercise\`, \`parent-dashboard\`, \`skilltree-mobile\`, \`skilltree-preview\`) now fill the new confirm-password field.

## Test plan
- [ ] \`cd frontend && npm run build\` — clean
- [ ] \`cd frontend && npm run lint\` — clean
- [ ] \`cd frontend && npm run test:e2e\` (against the running docker stack) — all green, including the new \`ux-audit.spec.js\`
- [ ] Manual at 375 px: tap each Login / Register / ChildPicker / Exercise input → no iOS zoom
- [ ] Manual at ~1300 px: LevelGauge sits beside the card, not floating
- [ ] Manual: Diagnostic \"Quitter\" → dialog; Esc cancels; Enter quits
- [ ] Manual at 320 px: DiagnosticResult count cards stack to one column without truncation
- [ ] Manual: NumberPad comma is visually distinct from zero; backspace icon is clearly tappable

🤖 Generated with [Claude Code](https://claude.com/claude-code)