### PR TITLE
feat: horizontal LevelGauge for mobile diagnostic

### DIFF
--- a/frontend/src/components/exercises/ExerciseCard.jsx
+++ b/frontend/src/components/exercises/ExerciseCard.jsx
@@ -17,21 +17,21 @@ function bindTrailingPunctuation(text) {
   return text.replace(/\s+([?!:;])/g, "\u00A0$1")
 }
 
-function renderInput(inputType, props) {
+function renderInput(inputType, key, props) {
   switch (inputType) {
     case "mcq":
-      return <McqInput {...props} />
+      return <McqInput key={key} {...props} />
     case "symbol":
-      return <SymbolInput {...props} />
+      return <SymbolInput key={key} {...props} />
     case "decomposition":
-      return <DecompositionInput {...props} />
+      return <DecompositionInput key={key} {...props} />
     case "point_on_line":
-      return <PointOnLineInput {...props} />
+      return <PointOnLineInput key={key} {...props} />
     case "drag_order":
-      return <DragOrderInput {...props} />
+      return <DragOrderInput key={key} {...props} />
     case "number":
     default:
-      return <NumberInput {...props} />
+      return <NumberInput key={key} {...props} />
   }
 }
 
@@ -72,8 +72,7 @@ export default function ExerciseCard({
       {!feedback && mode !== "diagnostic" && !examMode && <HintPanel exercise={exercise} />}
 
       {!feedback &&
-        renderInput(exercise.input_type, {
-          key: exercise.template_id,
+        renderInput(exercise.input_type, exercise.template_id, {
           exercise,
           grade,
           disabled,

--- a/frontend/src/components/exercises/LevelGauge.jsx
+++ b/frontend/src/components/exercises/LevelGauge.jsx
@@ -1,13 +1,51 @@
 const GRADES = ["P1", "P2", "P3", "P4", "P5", "P6"]
 const TOTAL_STEPS = GRADES.length * 3
 
-export default function LevelGauge({ grade, difficulty }) {
+export default function LevelGauge({ grade, difficulty, orientation = "vertical" }) {
   const gradeIdx = GRADES.indexOf(grade)
   const diff = Math.min(Math.max(difficulty || 1, 1), 3)
   const valid = gradeIdx >= 0
 
   const step = valid ? gradeIdx * 3 + diff : 0
   const fillPct = valid ? (step / TOTAL_STEPS) * 100 : 0
+  const footer = valid ? `${grade} · d${diff}` : "—"
+
+  if (orientation === "horizontal") {
+    return (
+      <div
+        className="flex items-center gap-3 w-full"
+        data-testid="level-gauge"
+        data-orientation="horizontal"
+      >
+        <span className="text-[10px] uppercase tracking-widest text-stem shrink-0">
+          Niveau
+        </span>
+
+        <div className="relative flex-1 h-2.5 rounded-full bg-mist overflow-hidden border border-sage/15">
+          <div
+            className="absolute inset-y-0 left-0 bg-gradient-to-r from-sage-leaf via-sage to-sage-deep transition-all duration-700 ease-out"
+            style={{ width: `${fillPct}%` }}
+          />
+          {GRADES.slice(1).map((g, i) => (
+            <div
+              key={g}
+              className="absolute top-0 bottom-0 w-px bg-sage/25"
+              style={{ left: `${((i + 1) / GRADES.length) * 100}%` }}
+            />
+          ))}
+          <div
+            className="absolute top-1/2 -translate-y-1/2 w-3.5 h-3.5 rounded-full bg-bone border-2 border-sage-deep shadow-md transition-all duration-700 ease-out"
+            style={{ left: `calc(${fillPct}% - 7px)` }}
+            aria-hidden
+          />
+        </div>
+
+        <span className="text-[11px] text-bark font-mono tabular-nums shrink-0">
+          {footer}
+        </span>
+      </div>
+    )
+  }
 
   return (
     <div className="flex flex-col items-center gap-2" data-testid="level-gauge">
@@ -50,9 +88,7 @@ export default function LevelGauge({ grade, difficulty }) {
         </div>
       </div>
 
-      <div className="text-[10px] text-stem font-mono tabular-nums">
-        {valid ? `${grade} · d${diff}` : "—"}
-      </div>
+      <div className="text-[10px] text-stem font-mono tabular-nums">{footer}</div>
     </div>
   )
 }

--- a/frontend/src/components/screens/DiagnosticScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticScreen.jsx
@@ -61,13 +61,20 @@ export default function DiagnosticScreen() {
     >
       <div className="flex-1 flex flex-col items-center px-5 sm:px-6 py-6 sm:py-8">
         {current && (
-          <div className="w-full max-w-xl mb-4" data-testid="diagnostic-progress">
+          <div className="w-full max-w-xl mb-4 space-y-2" data-testid="diagnostic-progress">
             <ProgressBar
               value={progress}
               max={total}
               tone="sage"
               label={`Question ${progress} / ${total}`}
             />
+            <div className="lg:hidden" data-testid="diagnostic-level-gauge-mobile">
+              <LevelGauge
+                orientation="horizontal"
+                grade={current?.cursor?.grade || current?.skill?.grade}
+                difficulty={current?.cursor?.difficulty || current?.difficulty}
+              />
+            </div>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
Follow-up to #139. The vertical LevelGauge was hidden below `lg`, so phone / small-tablet students on the Diagnostic screen lost the \"where am I on the P1–P6 ladder\" signal. This adds an `orientation` prop and a compact **horizontal** variant shown under the progress bar below `lg`; the vertical bar still sits next to the card at `lg+`.

- `LevelGauge` now takes `orientation=\"vertical\" | \"horizontal\"` (default unchanged).
- Horizontal variant: thin gradient strip with P1→P6 tick marks, a position dot, `Niveau` caption, and a `P3 · d1` footer chip.
- `DiagnosticScreen` renders the horizontal strip directly under `<ProgressBar>`, only visible on `lg:hidden`; the existing desktop placement is untouched.

## Test plan
- [ ] `cd frontend && npm run build` — clean
- [ ] `cd frontend && npm run lint` — clean
- [ ] Manual at 375 px: Diagnostic shows progress bar + horizontal level strip; no vertical gauge
- [ ] Manual at 1440 px: Diagnostic shows vertical gauge next to card; no horizontal strip
- [ ] Manual: `data-testid=\"diagnostic-level-gauge-mobile\"` tracks the cursor grade/difficulty across questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)