### PR TITLE
feat(#142): useFeedback() hook + inputmode audit

### DIFF
--- a/frontend/src/components/exercises/FeedbackMessage.jsx
+++ b/frontend/src/components/exercises/FeedbackMessage.jsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import { LatinLabel } from "../ui/Heading"
-import { playCorrect, playIncorrect } from "../../hooks/useSound"
+import { useFeedback } from "../../lib/feedback"
 
 function StrategyTabs({ strategies }) {
   const [active, setActive] = useState(0)
@@ -75,11 +75,12 @@ function ExplainSection({ feedback, explanation, explaining, onExplain }) {
 
 export default function FeedbackMessage({ feedback, explanation, explaining, onExplain, neutral }) {
   const ok = feedback?.is_correct
+  const cues = useFeedback()
   useEffect(() => {
     if (!feedback || neutral) return
-    if (ok) playCorrect()
-    else playIncorrect()
-  }, [feedback, ok, neutral])
+    if (ok) cues.correct()
+    else cues.wrong()
+  }, [feedback, ok, neutral, cues])
   if (!feedback) return null
 
   if (neutral) {

--- a/frontend/src/lib/feedback.js
+++ b/frontend/src/lib/feedback.js
@@ -1,0 +1,30 @@
+import { useMemo } from "react"
+import { playBadge, playCorrect, playIncorrect } from "../hooks/useSound"
+
+const vibrate = (pattern) => {
+  if (typeof navigator === "undefined" || typeof navigator.vibrate !== "function") return
+  try {
+    navigator.vibrate(pattern)
+  } catch {
+    // Some browsers throw on unsupported patterns — silent fallback.
+  }
+}
+
+export const useFeedback = () =>
+  useMemo(
+    () => ({
+      correct: () => {
+        vibrate(15)
+        playCorrect()
+      },
+      wrong: () => {
+        vibrate([40, 60, 40])
+        playIncorrect()
+      },
+      levelUp: () => {
+        vibrate([10, 30, 10, 30, 60])
+        playBadge()
+      },
+    }),
+    [],
+  )


### PR DESCRIPTION
## Summary
- Adds `frontend/src/lib/feedback.js` exposing `useFeedback()` with `.correct() / .wrong() / .levelUp()`; each fires `navigator.vibrate` (guarded, silent fallback) alongside the existing `useSound` tones.
- `FeedbackMessage` now consumes the hook instead of calling `playCorrect` / `playIncorrect` directly, so Exercise + Drill (and any future `ExerciseCard` consumer) pick up haptics without extra wiring.
- Closes the inputmode half of #142 by verification rather than new code — audit findings were already addressed:
  - `NumberInput` uses a custom on-screen `NumberPad` (better than exposing the OS keyboard — so the AC's `inputmode="numeric"` is N/A).
  - `SymbolInput` / `McqInput` / `PointOnLineInput` / `DragOrderInput` have no `<input>` elements.
  - `DecompositionInput` already sets `inputMode="numeric"`.
  - `LoginScreen` / `RegisterScreen` already set `autoComplete` + `inputMode` on every field.
  - `src/index.css:63-67` already forces `font-size: 16px` on `input/select/textarea` globally → iOS auto-zoom is already handled.

Scope split out of #123, which now tracks only port-dependent scaffolding (navigation pattern, query persister, i18n, font bundling).

## Test plan
- [ ] `npm run lint` green ✅
- [ ] `npm run build` green ✅
- [ ] Manual: submit a correct answer in Exercise mode on a phone → short vibrate + success tone
- [ ] Manual: submit a wrong answer → longer triple-pulse vibrate + low tone
- [ ] Manual: exam mode (`neutral` flag) stays silent — no sound, no haptic
- [ ] Manual: browser without `navigator.vibrate` (desktop Chrome) → sound still plays, no errors

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)