### PR TITLE
fix(ci): deploy on tag push, not main push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,7 +76,7 @@ jobs:
 
   deploy:
     needs: build
-    if: github.ref_type == 'branch'
+    if: github.ref_type == 'tag' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: production
     steps:


### PR DESCRIPTION
## Summary
Gates the prod deploy on tag push (and workflow_dispatch) instead of main push, so `git describe --tags` at build time sees the release tag and stamps `APP_VERSION=vX.Y.Z` correctly.

Root cause of the `v0.2.0-1-gddf88b0` version stamp seen in prod right after PR #144: the deploy fired on main-push **before** the `v0.3.0` tag existed, so `git describe` fell back to "last tag + commits since." The release skill already guarantees a tag follows every main merge within seconds, so moving the deploy trigger to the tag push doesn't delay anything — it just ensures the version label reflects reality.

## Note on PR #145
PR #145 attempted this same fix but silently merged empty (squash commit `ee609dc` has zero diff vs parent) because the `gh` token used to perform the merge lacked the `workflow` scope. GitHub stripped the workflow-file change from the squash without an error. This PR needs to be merged via the **GitHub web UI** (browser session has full scope by default) or with a token that has `workflow`.

## Test plan
- [ ] Merge via the GitHub UI (Squash and merge)
- [ ] Tag the merge commit `v0.3.2`, push
- [ ] Verify only the tag-push Deploy workflow fires (no main-push deploy this time)
- [ ] `curl https://collegia.be/api/health/` → `"version": "v0.3.2"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)