### PR TITLE
fix(#155): suppress loading flash on bootstrap refetch

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,14 +25,14 @@ import "./App.css"
 function RequireAuth({ children }) {
   const { user, loading } = useAuthStore()
   const location = useLocation()
-  if (loading) return <div className="p-8 text-center">Chargement…</div>
+  if (loading && !user) return <div className="p-8 text-center">Chargement…</div>
   if (!user) return <Navigate to="/login" replace state={{ from: location }} />
   return children
 }
 
 function RootRoute() {
   const { user, loading } = useAuthStore()
-  if (loading) return <div className="p-8 text-center">Chargement…</div>
+  if (loading && !user) return <div className="p-8 text-center">Chargement…</div>
   return user ? <WelcomeScreen /> : <LandingScreen />
 }
 

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -29,7 +29,8 @@ export const useAuthStore = create((set, get) => ({
   error: null,
 
   bootstrap: async () => {
-    set({ loading: true, error: null })
+    const hadUser = get().user !== null
+    set({ loading: !hadUser, error: null })
     try {
       await api.bootstrapCsrf()
       const user = await api.get("/auth/user/")


### PR DESCRIPTION
## Summary
- `authStore.bootstrap` no longer flips `loading: true` when a user is already loaded — only on the cold-start path
- `RootRoute` and `RequireAuth` only render the bare "Chargement…" fallback when `loading && !user`, so post-bootstrap refetches don't blank the screen

Fixes #155.

## Test plan
- [ ] Cold-load (signed out) still shows the fallback until `/auth/user/` resolves, then renders LandingScreen
- [ ] Cold-load (signed in) still shows the fallback, then renders WelcomeScreen
- [ ] Click « Arrêter » mid-exercise → navigates to `/` with no blank-screen flash, XP/streak reflect the just-finished session
- [ ] Same applies to Diagnostic, Drill, Exam stop flows (all four call `bootstrap()` after `stop()`)
- [ ] Logout still routes to `/login` cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)