### PR TITLE
feat(#157): neutral status labels + plant-based mastery summary

### DIFF
--- a/backend/apps/students/serializers.py
+++ b/backend/apps/students/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers
 
+from apps.skills.models import Skill
 from apps.students.services.achievements import serialize_badge
 from apps.students.services.streaks import daily_progress
 
@@ -7,7 +8,12 @@ from .models import GRADE_VALUES, Student, StudentAchievement, StudentSkillState
 
 
 def mastery_counts(student: Student) -> dict:
-    """Count skill states by computed status bucket, plus an `in_progress` aggregate."""
+    """Count skill states by computed status bucket, plus an `in_progress` aggregate.
+
+    Counts cover the full skill catalog (all grades). Untouched skills with no
+    StudentSkillState row land in `not_started` — rows are created lazily on
+    the first attempt, so the catalog is the source of truth.
+    """
     out = {
         StudentSkillState.NOT_STARTED: 0,
         StudentSkillState.LEARNING_EASY: 0,
@@ -18,6 +24,9 @@ def mastery_counts(student: Student) -> dict:
     }
     for state in StudentSkillState.objects.filter(student=student):
         out[state.status] = out.get(state.status, 0) + 1
+    total = Skill.objects.count()
+    touched = sum(v for k, v in out.items() if k != StudentSkillState.NOT_STARTED)
+    out[StudentSkillState.NOT_STARTED] = max(0, total - touched)
     out["in_progress"] = (
         out[StudentSkillState.LEARNING_EASY]
         + out[StudentSkillState.LEARNING_MEDIUM]

--- a/backend/tests/test_mastery.py
+++ b/backend/tests/test_mastery.py
@@ -3,6 +3,8 @@ import pytest
 from apps.exercises.models import ExerciseTemplate, TemplateSkillWeight
 from apps.skills.models import Skill
 from apps.students.models import SKILL_XP_MAX, Student, StudentSkillState
+from apps.students.serializers import mastery_counts
+from apps.students.services.grade_seeding import seed_prior_grade_mastery
 from apps.students.services.mastery import apply_template_attempt
 
 
@@ -77,6 +79,40 @@ def test_creates_state_if_missing(student, skill, single_skill_template):
     assert not StudentSkillState.objects.filter(student=student, skill=skill).exists()
     apply_template_attempt(student, single_skill_template, True)
     assert StudentSkillState.objects.filter(student=student, skill=skill).exists()
+
+
+@pytest.mark.django_db
+def test_mastery_counts_covers_full_catalog_for_p1_student(user):
+    """A P1 student with no attempts: every catalog skill sits in `not_started`."""
+    s = Student.objects.create(user=user, display_name="Z", grade="P1")
+    total = Skill.objects.count()
+    counts = mastery_counts(s)
+    assert counts["not_started"] == total
+    assert counts["mastered"] == 0
+    assert counts["in_progress"] == 0
+
+
+@pytest.mark.django_db
+def test_mastery_counts_higher_grade_student_sees_full_catalog(user):
+    """P3 student: prior-grade auto-mastery → Acquis, the rest sits in À découvrir."""
+    s = Student.objects.create(user=user, display_name="Z", grade="P3")
+    seed_prior_grade_mastery(s)
+    total = Skill.objects.count()
+    lower = Skill.objects.filter(grade__lt="P3").count()
+    counts = mastery_counts(s)
+    assert counts["mastered"] == lower
+    assert counts["not_started"] == total - lower
+
+
+@pytest.mark.django_db
+def test_mastery_counts_attempted_skill_moves_out_of_not_started(
+    student, skill, single_skill_template
+):
+    before = mastery_counts(student)["not_started"]
+    apply_template_attempt(student, single_skill_template, True)
+    after = mastery_counts(student)
+    assert after["not_started"] == before - 1
+    assert after["in_progress"] == 1
 
 
 @pytest.mark.django_db

--- a/frontend/src/components/screens/DiagnosticResult.jsx
+++ b/frontend/src/components/screens/DiagnosticResult.jsx
@@ -8,9 +8,9 @@ import { Heading, LatinLabel } from "../ui/Heading"
 import { downloadDiagnosticPdf } from "../../api/history"
 
 const BUCKET_STYLES = {
-  green: { ring: "stroke-sage", fill: "bg-sage", text: "text-sage-deep", soft: "bg-sage-leaf/40", label: "En croissance" },
-  orange: { ring: "stroke-honey", fill: "bg-honey", text: "text-honey", soft: "bg-honey/15", label: "À arroser" },
-  red: { ring: "stroke-rose", fill: "bg-rose", text: "text-rose", soft: "bg-rose/15", label: "Graine" },
+  green: { ring: "stroke-sage", fill: "bg-sage", text: "text-sage-deep", soft: "bg-sage-leaf/40", label: "En cours" },
+  orange: { ring: "stroke-honey", fill: "bg-honey", text: "text-honey", soft: "bg-honey/15", label: "À revoir" },
+  red: { ring: "stroke-rose", fill: "bg-rose", text: "text-rose", soft: "bg-rose/15", label: "À découvrir" },
 }
 
 const LEVEL_COPY = {
@@ -260,9 +260,9 @@ export default function DiagnosticResult({
           }`}
           data-testid="diagnostic-counts"
         >
-          <CountCard tone="green" label="En croissance" value={counts.green} delay={520} />
-          <CountCard tone="orange" label="À arroser" value={counts.orange} delay={620} />
-          <CountCard tone="red" label="Graines" value={counts.red} delay={720} />
+          <CountCard tone="green" label="En cours" value={counts.green} delay={520} />
+          <CountCard tone="orange" label="À revoir" value={counts.orange} delay={620} />
+          <CountCard tone="red" label="À découvrir" value={counts.red} delay={720} />
         </div>
 
         {years.length > 0 && (
@@ -290,7 +290,7 @@ export default function DiagnosticResult({
           <div className="mb-6">
             <div className="flex items-center gap-2 mb-2">
               <Icon name="target" className="text-sky-deep" />
-              <Heading level={4}>À arroser</Heading>
+              <Heading level={4}>À revoir</Heading>
             </div>
             <ul className="text-sm text-bark space-y-1 pl-6">
               {result.weaknesses.map((s) => <li key={s.skill_id}>• {s.label}</li>)}

--- a/frontend/src/components/screens/ParentDashboardScreen.jsx
+++ b/frontend/src/components/screens/ParentDashboardScreen.jsx
@@ -67,10 +67,10 @@ function StudentCard({ student, onOpenDetail }) {
           </div>
           <ProgressBar value={m.mastered || 0} max={Math.max(total, 1)} tone="sage" />
           <div className="flex flex-wrap gap-1.5">
-            <Chip tone="sage">{m.mastered || 0} floraison</Chip>
-            <Chip tone="sky">{m.in_progress || 0} en croissance</Chip>
-            <Chip tone="honey">{m.needs_review || 0} à arroser</Chip>
-            <Chip tone="bark">{m.not_started || 0} en sommeil</Chip>
+            <Chip tone="sage">{m.mastered || 0} acquis</Chip>
+            <Chip tone="sky">{m.in_progress || 0} en cours</Chip>
+            <Chip tone="honey">{m.needs_review || 0} à revoir</Chip>
+            <Chip tone="bark">{m.not_started || 0} à découvrir</Chip>
           </div>
         </section>
 

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -550,19 +550,22 @@ export default function SkillTreeScreen() {
 
 function StatusLegend() {
   const items = [
-    { label: "Floraison", color: "#E8C66A" },
-    { label: "En croissance", color: "#6FA274" },
-    { label: "À arroser", color: "#4F8BAC" },
-    { label: "En sommeil", color: "#A1AEA3" },
+    { status: "locked", mastery: 0, label: "À découvrir" },
+    { status: "in_progress", mastery: 0.1, label: "Découverte" },
+    { status: "in_progress", mastery: 0.55, label: "En cours" },
+    { status: "done", mastery: 1, label: "Acquis" },
+    { status: "wilted", mastery: 0, label: "À revoir" },
   ]
   return (
     <Card
-      className="hidden md:flex absolute top-4 left-4 z-10 flex-col gap-1.5 px-3 py-2.5"
+      className="hidden md:flex absolute top-4 left-4 z-10 flex-col gap-1 px-3 py-2"
       aria-label="Légende"
     >
-      {items.map(({ label, color }) => (
+      {items.map(({ status, mastery, label }) => (
         <div key={label} className="flex items-center gap-2 text-[11px] text-bark">
-          <span className="w-2.5 h-2.5 rounded-full" style={{ background: color }} />
+          <span className="w-6 h-6 flex items-center justify-center shrink-0">
+            <Plant status={status} mastery={mastery} size={22} />
+          </span>
           {label}
         </div>
       ))}
@@ -573,12 +576,12 @@ function StatusLegend() {
 const SKILL_XP_MAX = 30
 
 const STATUS_LABEL = {
-  mastered: "Maîtrisé",
-  learning_hard: "Presque fleuri",
-  learning_medium: "En croissance",
-  learning_easy: "Première pousse",
+  mastered: "Acquis",
+  learning_hard: "Presque acquis",
+  learning_medium: "En cours",
+  learning_easy: "Découverte",
   needs_review: "À revoir",
-  not_started: "À commencer",
+  not_started: "À découvrir",
 }
 
 const STATUS_DOT = {

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -10,7 +10,7 @@ import {
   useReactFlow,
 } from "@xyflow/react"
 import "@xyflow/react/dist/style.css"
-import { useNavigate } from "react-router"
+import { useNavigate, useSearchParams } from "react-router"
 import { useQuery } from "@tanstack/react-query"
 import { api } from "../../api/client"
 import { useAuthStore } from "../../stores/authStore"
@@ -72,6 +72,30 @@ function pickFocusSkill(skills, stateById) {
   return best?.id ?? null
 }
 
+const FOCUS_BUCKET_STATUSES = {
+  not_started: ["not_started"],
+  learning_easy: ["learning_easy"],
+  in_progress: ["learning_medium", "learning_hard"],
+  mastered: ["mastered"],
+  needs_review: ["needs_review"],
+}
+
+function pickSkillForBucket(skills, stateById, bucket) {
+  const wanted = FOCUS_BUCKET_STATUSES[bucket]
+  if (!wanted) return null
+  const set = new Set(wanted)
+  for (const s of skills) {
+    const st = stateById.get(s.id)
+    if (st && set.has(st.status)) return s.id
+  }
+  if (set.has("not_started")) {
+    for (const s of skills) {
+      if (!stateById.get(s.id)) return s.id
+    }
+  }
+  return null
+}
+
 function useIsMobile() {
   const [isMobile, setIsMobile] = useState(
     typeof window !== "undefined" ? window.innerWidth < MOBILE_BREAKPOINT : false
@@ -104,10 +128,16 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
     return map
   }, [skillTreeData])
 
-  const focusId = useMemo(
-    () => (skills ? pickFocusSkill(skills, stateById) : null),
-    [skills, stateById]
-  )
+  const [searchParams] = useSearchParams()
+  const focusBucket = searchParams.get("focus")
+  const focusId = useMemo(() => {
+    if (!skills) return null
+    if (focusBucket) {
+      const bucketId = pickSkillForBucket(skills, stateById, focusBucket)
+      if (bucketId) return bucketId
+    }
+    return pickFocusSkill(skills, stateById)
+  }, [skills, stateById, focusBucket])
 
   const skillsById = useMemo(() => {
     const map = new Map()

--- a/frontend/src/components/screens/WelcomeScreen.jsx
+++ b/frontend/src/components/screens/WelcomeScreen.jsx
@@ -15,32 +15,58 @@ import XPBar from "../xp/XPBar"
 import StreakFlame from "../streak/StreakFlame"
 import DailyGoalProgress from "../streak/DailyGoalProgress"
 import BadgeGallery from "../badges/BadgeGallery"
+import Plant from "../ui/Plant"
 
-const STATUS_LABELS = {
-  not_started: "En sommeil",
-  in_progress: "En croissance",
-  mastered: "Floraison",
-  needs_review: "À arroser",
-}
-
-const STATUS_TONES = {
-  not_started: "text-twig",
-  in_progress: "text-sage-deep",
-  mastered: "text-honey",
-  needs_review: "text-sky-deep",
-}
+const MASTERY_BUCKETS = [
+  {
+    key: "not_started",
+    label: "À découvrir",
+    plant: { status: "locked", mastery: 0 },
+    tone: "text-twig",
+    count: (s) => s.not_started ?? 0,
+  },
+  {
+    key: "learning_easy",
+    label: "Découverte",
+    plant: { status: "in_progress", mastery: 0.1 },
+    tone: "text-sage",
+    count: (s) => s.learning_easy ?? 0,
+  },
+  {
+    key: "in_progress",
+    label: "En cours",
+    plant: { status: "in_progress", mastery: 0.55 },
+    tone: "text-sage-deep",
+    count: (s) => (s.learning_medium ?? 0) + (s.learning_hard ?? 0),
+  },
+  {
+    key: "mastered",
+    label: "Acquis",
+    plant: { status: "done", mastery: 1 },
+    tone: "text-honey",
+    count: (s) => s.mastered ?? 0,
+  },
+  {
+    key: "needs_review",
+    label: "À revoir",
+    plant: { status: "wilted", mastery: 0 },
+    tone: "text-sky-deep",
+    count: (s) => s.needs_review ?? 0,
+  },
+]
 
 function MasterySummary({ summary }) {
   if (!summary) return null
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-      {Object.keys(STATUS_LABELS).map((k) => (
-        <Card key={k} className="p-4 text-center">
-          <div className={`font-mono text-3xl font-semibold ${STATUS_TONES[k]}`}>
-            {summary[k] ?? 0}
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
+      {MASTERY_BUCKETS.map(({ key, label, plant, tone, count }) => (
+        <Card key={key} className="p-3 flex flex-col items-center text-center">
+          <Plant status={plant.status} mastery={plant.mastery} size={36} />
+          <div className={`font-mono text-2xl font-semibold mt-1 ${tone}`}>
+            {count(summary)}
           </div>
-          <div className="text-[11px] uppercase tracking-wider text-stem mt-1">
-            {STATUS_LABELS[k]}
+          <div className="text-[11px] uppercase tracking-wider text-stem mt-0.5">
+            {label}
           </div>
         </Card>
       ))}

--- a/frontend/src/components/screens/WelcomeScreen.jsx
+++ b/frontend/src/components/screens/WelcomeScreen.jsx
@@ -22,14 +22,16 @@ const MASTERY_BUCKETS = [
     key: "not_started",
     label: "À découvrir",
     plant: { status: "locked", mastery: 0 },
-    tone: "text-twig",
+    tone: "text-stem",
+    focus: "not_started",
     count: (s) => s.not_started ?? 0,
   },
   {
     key: "learning_easy",
     label: "Découverte",
     plant: { status: "in_progress", mastery: 0.1 },
-    tone: "text-sage",
+    tone: "text-stem",
+    focus: "learning_easy",
     count: (s) => s.learning_easy ?? 0,
   },
   {
@@ -37,13 +39,15 @@ const MASTERY_BUCKETS = [
     label: "En cours",
     plant: { status: "in_progress", mastery: 0.55 },
     tone: "text-sage-deep",
+    focus: "in_progress",
     count: (s) => (s.learning_medium ?? 0) + (s.learning_hard ?? 0),
   },
   {
     key: "mastered",
     label: "Acquis",
     plant: { status: "done", mastery: 1 },
-    tone: "text-honey",
+    tone: "text-stem",
+    focus: "mastered",
     count: (s) => s.mastered ?? 0,
   },
   {
@@ -51,26 +55,56 @@ const MASTERY_BUCKETS = [
     label: "À revoir",
     plant: { status: "wilted", mastery: 0 },
     tone: "text-sky-deep",
+    focus: "needs_review",
     count: (s) => s.needs_review ?? 0,
   },
 ]
 
-function MasterySummary({ summary }) {
+function MasterySummary({ summary, onFocus }) {
   if (!summary) return null
+  const total = MASTERY_BUCKETS.reduce((sum, b) => sum + b.count(summary), 0)
+  const started = total - (summary.not_started ?? 0)
   return (
-    <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
-      {MASTERY_BUCKETS.map(({ key, label, plant, tone, count }) => (
-        <Card key={key} className="p-3 flex flex-col items-center text-center">
-          <Plant status={plant.status} mastery={plant.mastery} size={36} />
-          <div className={`font-mono text-2xl font-semibold mt-1 ${tone}`}>
-            {count(summary)}
-          </div>
-          <div className="text-[11px] uppercase tracking-wider text-stem mt-0.5">
-            {label}
-          </div>
-        </Card>
-      ))}
-    </div>
+    <section aria-labelledby="mastery-heading">
+      <div className="flex items-baseline justify-between mb-3">
+        <Heading level={4} id="mastery-heading">
+          Maîtrise
+        </Heading>
+        <span className="font-mono text-xs text-stem tabular-nums">
+          {started} / {total} commencé
+        </span>
+      </div>
+      <div className="grid grid-cols-3 md:grid-cols-5 gap-3">
+        {MASTERY_BUCKETS.map(({ key, label, plant, tone, focus, count }) => {
+          const value = count(summary)
+          const interactive = value > 0
+          return (
+            <button
+              key={key}
+              type="button"
+              disabled={!interactive}
+              onClick={() => interactive && onFocus(focus)}
+              data-testid={`mastery-card-${key}`}
+              className={`bg-paper border border-sage/15 rounded-2xl p-3 flex flex-col items-center text-center transition-colors duration-200 ${
+                interactive
+                  ? "cursor-pointer hover:bg-sage-leaf/30 hover:border-sage/35 focus:outline-none focus-visible:ring-2 focus-visible:ring-sage-deep"
+                  : "opacity-55 cursor-default"
+              }`}
+            >
+              <span className="h-12 flex items-end justify-center">
+                <Plant status={plant.status} mastery={plant.mastery} size={36} />
+              </span>
+              <span className={`font-mono text-2xl font-semibold mt-1 ${tone}`}>
+                {value}
+              </span>
+              <span className="text-[11px] uppercase tracking-wider text-stem mt-0.5">
+                {label}
+              </span>
+            </button>
+          )
+        })}
+      </div>
+    </section>
   )
 }
 
@@ -129,7 +163,10 @@ export default function WelcomeScreen() {
         </Card>
 
         <div className="mb-6">
-          <MasterySummary summary={child.mastery_summary} />
+          <MasterySummary
+            summary={child.mastery_summary}
+            onFocus={(bucket) => navigate(`/skill-tree?focus=${bucket}`)}
+          />
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-8">

--- a/frontend/src/components/ui/SkillListView.jsx
+++ b/frontend/src/components/ui/SkillListView.jsx
@@ -1,26 +1,16 @@
 import { useMemo } from "react"
 import { GRADES, GRADE_COLORS } from "../../lib/skillTreeLayout"
 import { levelDescriptions, levelLatin, levelVernacular } from "../../lib/constants"
+import { SENTIER_LABEL, SENTIER_DOT } from "../../lib/skillStatus"
 
-const STATE_LABEL = {
-  floraison: "Floraison",
-  croissance: "En croissance",
-  arroser: "À arroser",
-  sommeil: "En sommeil",
-}
-
-const STATE_COLOR = {
-  floraison: "#E8C66A",
-  croissance: "#6FA274",
-  arroser: "#4F8BAC",
-  sommeil: "#A1AEA3",
-}
+const STATE_LABEL = SENTIER_LABEL
+const STATE_COLOR = SENTIER_DOT
 
 const STATUS_TO_STATE = {
-  completed: "floraison",
-  in_progress: "croissance",
-  review: "arroser",
-  locked: "sommeil",
+  completed: "done",
+  in_progress: "in_progress",
+  review: "wilted",
+  locked: "locked",
 }
 
 function LockIcon({ className = "" }) {
@@ -89,7 +79,7 @@ export default function SkillListView({
             <ul className="space-y-1.5">
               {items.map((n) => {
                 const d = n.data
-                const state = STATUS_TO_STATE[d.status] ?? "sommeil"
+                const state = STATUS_TO_STATE[d.status] ?? "locked"
                 const pct = Math.round((d.masteryLevel ?? 0) * 100)
                 const attempts = d.totalAttempts ?? 0
                 const locked = !d.unlocked

--- a/frontend/src/components/ui/SkillNode.jsx
+++ b/frontend/src/components/ui/SkillNode.jsx
@@ -1,15 +1,10 @@
 import { useContext } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
+import { SENTIER_LABEL } from "../../lib/skillStatus"
 import Plant from "./Plant"
 
-const STATE_LABEL = {
-  done: "Floraison",
-  in_progress: "En croissance",
-  wilted: "À arroser",
-  unlocked: "À commencer",
-  locked: "En sommeil",
-}
+const STATE_LABEL = SENTIER_LABEL
 
 function LockIcon() {
   return (
@@ -117,7 +112,7 @@ export default function SkillNode({ id, data }) {
       )}
       {isToday && sentierStatus !== "wilted" && (
         <span className="disc-mini" style={{ color: "#8a6a1f" }}>
-          · à arroser aujourd'hui ·
+          · à pratiquer aujourd'hui ·
         </span>
       )}
       {totalAttempts === 0 && sentierStatus === "unlocked" && !isToday && (

--- a/frontend/src/lib/skillStatus.js
+++ b/frontend/src/lib/skillStatus.js
@@ -1,0 +1,36 @@
+// Backend StudentSkillState.status — 6 tiers, see apps/students/models.py
+export const STATUS_LABEL = {
+  not_started: "À découvrir",
+  learning_easy: "Découverte",
+  learning_medium: "En cours",
+  learning_hard: "Presque acquis",
+  mastered: "Acquis",
+  needs_review: "À revoir",
+}
+
+export const STATUS_DOT = {
+  not_started: "#A1AEA3",
+  learning_easy: "#C7E0B5",
+  learning_medium: "#6FA274",
+  learning_hard: "#3F6F4A",
+  mastered: "#E8C66A",
+  needs_review: "#4F8BAC",
+}
+
+// Frontend-derived state used by skill-tree visuals (SkillNode, SkillListView).
+// Computed by sentierStatusFor() in SkillTreeScreen.
+export const SENTIER_LABEL = {
+  done: "Acquis",
+  in_progress: "En cours",
+  wilted: "À revoir",
+  unlocked: "À commencer",
+  locked: "À découvrir",
+}
+
+export const SENTIER_DOT = {
+  done: "#E8C66A",
+  in_progress: "#6FA274",
+  wilted: "#4F8BAC",
+  unlocked: "#C7E0B5",
+  locked: "#A1AEA3",
+}


### PR DESCRIPTION
## Summary
- **Shared label module** — new `frontend/src/lib/skillStatus.js` centralises the 6-tier (backend) + 5-tier (sentier-derived) status labels and dot colors. Replaces ad-hoc botanical strings (Floraison / En croissance / À arroser / En sommeil) scattered across `SkillNode`, `SkillListView`, `SkillTreeScreen`, `WelcomeScreen`, `ParentDashboardScreen`, `DiagnosticResult`. `Floraison.jsx` (celebration) and `LandingScreen` marketing copy keep botanical wording on purpose.
- **Plant-based legends** — `SkillTreeScreen` legend and `WelcomeScreen` mastery cards both render the 5 distinct `Plant` images (graine / pousse / bouton / fleur / fanée) with neutral labels (À découvrir / Découverte / En cours / Acquis / À revoir).
- **Honest catalog totals** — backend `mastery_counts()` now derives `not_started` from `Skill.objects.count()` rather than from existing `StudentSkillState` rows. Rows are created lazily on first attempt, so previously a P1 student with one attempt saw "À découvrir: 0" instead of "À découvrir: 109". Buckets now sum to the full catalog.
- **Mastery cards become navigation** — clicking a card on the WelcomeScreen jumps to `/skill-tree?focus=<bucket>` and pre-focuses the tree on a matching skill. Zero-count cards are dim and disabled. Added a "Maîtrise · X / Y commencé" header above the grid, switched to 3-col mobile / 5-col desktop, and tightened the color hierarchy so À revoir and En cours pop while the rest stay muted.

Closes #157.

## Test plan
- [ ] WelcomeScreen mastery section: 5 cards in a row on desktop (3 + 2 on mobile), heading + denominator above, plants on a uniform baseline
- [ ] Click each non-zero card → routes to `/skill-tree?focus=<bucket>` and the tree centers on a matching skill
- [ ] Cards with count 0 are dimmed and not clickable
- [ ] SkillTreeScreen legend (top-left) shows 5 plant images with the new labels
- [ ] ParentDashboardScreen mastery chips read `acquis / en cours / à revoir / à découvrir`
- [ ] DiagnosticResult count cards + headings use the new wording
- [ ] `Floraison.jsx` celebration screen and LandingScreen marketing copy still use botanical wording
- [ ] Backend tests pass: `pytest tests/test_mastery.py tests/test_parent_overview.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)