### PR TITLE
feat(#154): remove Latin labels from the UI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,13 +138,13 @@ Key tables: `accounts_parent`, `students_student`, `skills_skill`, `skills_skill
 
 ## Design System
 
-**Le Jardin de PédagogIA** (*Hortus Mathematicus*). Reference preview: `design/JARDIN.html` + `design/jardin-screens/`. Migration tracked in #65.
+**Le Jardin de PédagogIA.** Reference preview: `design/JARDIN.html` + `design/jardin-screens/`. Migration tracked in #65.
 
 Metaphor: a calm botanical greenhouse. Each skill is a plant, each session a care ritual, each mastered skill a *floraison*. Four plant states: *en sommeil · à arroser · en croissance · floraison*.
 
 - **Palette** — `bone #FFFFFF` surface · `chalk #F6F8F3` page · `mist #ECF1E7` secondary · `sage #6FA274` primary · `sage-deep #3F6F4A` accent · `sage-leaf #C7E0B5` halos · `sky #B8DCEA` hints/IA · `sky-deep #4F8BAC` links · `bark #2B3A2E` text · `stem #5C6B5F` secondary text · `honey #E8C66A` XP (rare) · `rose #E8A6A1` soft error (never bright red)
-- **Type** — Display *Fraunces* (italic for Latin labels) · UI *Inter* 14–16px · numerals *JetBrains Mono* tabular
-- **Primitives** — `.greenhouse`, `.paper-grid`, `.water`, `.tag`, `.chip`, `.pill`, `.pot`, `.specimen`, `.latin`, `.navlink` (see `src/index.css`); components in `frontend/src/components/ui/`
+- **Type** — Display *Fraunces* (italic for display accents) · UI *Inter* 14–16px · numerals *JetBrains Mono* tabular
+- **Primitives** — `.greenhouse`, `.paper-grid`, `.water`, `.tag`, `.chip`, `.pill`, `.pot`, `.specimen`, `.navlink` (see `src/index.css`); components in `frontend/src/components/ui/`
 - **Screen vocabulary** — ① Serre (Welcome) · ② Carnets (ChildPicker) · ③ Carte (SkillTree) · ④ Établi (Exercise) · ⑤ Jardinier (feedback/investigation) · ⑥ Herbier (progress) · ⑦ Floraison (celebration)
 - **Principles** — 60% white / 25% pale green / 15% accent · SVG only (no emojis in UI) · 200ms transitions, soft shadows · no mascot, no claymorphism, no indigo/violet, no bright red
 

--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -80,7 +80,7 @@ Ombres : `--shadow-leaf` · `--shadow-dew` · `--shadow-tag` · `--shadow-glassp
 
 Dans `frontend/src/components/ui/` — chaque composant sous 80 lignes :
 
-`Button` · `Card` · `Chip` · `Input` · `Heading` + `LatinLabel` · `Icon` (wrapper lucide-react) · `Pot` · `ProgressBar` · `SkillNode` · `Floraison`.
+`Button` · `Card` · `Chip` · `Input` · `Heading` · `Icon` (wrapper lucide-react) · `Pot` · `ProgressBar` · `SkillNode` · `Floraison`.
 
 Règle : Tailwind d'abord ; CSS custom seulement pour les effets (textures, ombres, tags à ficelle).
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -137,13 +137,6 @@
   color: var(--color-paper);
 }
 
-/* Fraunces italic label (botanical Latin) */
-.latin {
-  font-family: var(--font-display);
-  font-style: italic;
-  color: var(--color-stem);
-}
-
 /* Plant pot (ChildPicker) */
 .pot {
   background: var(--color-paper);

--- a/frontend/src/components/badges/BadgeToast.jsx
+++ b/frontend/src/components/badges/BadgeToast.jsx
@@ -27,7 +27,7 @@ export default function BadgeToast() {
     >
       <BadgeIcon icon={current.icon} tier={current.tier} size={48} />
       <div className="text-left">
-        <span className="latin text-[10px] uppercase tracking-wider">Novum signum</span>
+        <span className="text-[10px] uppercase tracking-wider text-stem">Nouveau badge</span>
         <div className="font-display font-semibold text-bark leading-tight">{current.label}</div>
         {current.description && (
           <div className="text-xs text-stem mt-0.5">{current.description}</div>

--- a/frontend/src/components/exercises/ExerciseCard.jsx
+++ b/frontend/src/components/exercises/ExerciseCard.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef } from "react"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
-import { LatinLabel } from "../ui/Heading"
 import HintPanel from "./HintPanel"
 import FeedbackMessage from "./FeedbackMessage"
 import NumberInput from "./inputs/NumberInput"
@@ -49,7 +48,7 @@ export default function ExerciseCard({
   if (!exercise) {
     return (
       <Card className="p-8 w-full max-w-md text-center">
-        <span className="latin text-stem">Germinatio…</span>
+        <span className="italic text-stem">Chargement…</span>
       </Card>
     )
   }
@@ -61,7 +60,7 @@ export default function ExerciseCard({
     <Card className="p-8 md:p-10 w-full max-w-md text-center">
       {skill && (
         <>
-          <LatinLabel>{skill.grade}</LatinLabel>
+          <span className="text-xs text-stem uppercase tracking-wider">{skill.grade}</span>
           <p className="font-display text-sm text-bark mt-0.5 mb-5">{skill.label}</p>
         </>
       )}

--- a/frontend/src/components/exercises/FeedbackMessage.jsx
+++ b/frontend/src/components/exercises/FeedbackMessage.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
-import { LatinLabel } from "../ui/Heading"
 import { useFeedback } from "../../lib/feedback"
 
 function StrategyTabs({ strategies }) {
@@ -51,9 +50,8 @@ function ExplainSection({ feedback, explanation, explaining, onExplain }) {
   if (explanation) {
     return (
       <div className="mt-4" data-testid="explanation">
-        <LatinLabel className="block text-center">Hortulanus</LatinLabel>
         {explanation.message && (
-          <p className="text-sm text-bark text-center mt-1">{explanation.message}</p>
+          <p className="text-sm text-bark text-center">{explanation.message}</p>
         )}
         {explanation.next_skill_id && (
           <p className="text-xs text-stem text-center mt-2">
@@ -86,8 +84,7 @@ export default function FeedbackMessage({ feedback, explanation, explaining, onE
   if (neutral) {
     return (
       <div className="mt-6 rounded-xl p-5 bg-mist border border-bark/5 text-center">
-        <LatinLabel className="block">Responsum acceptum</LatinLabel>
-        <div className="font-display text-lg text-bark mt-1">{feedback.message}</div>
+        <div className="font-display text-lg text-bark">{feedback.message}</div>
       </div>
     )
   }
@@ -107,9 +104,8 @@ export default function FeedbackMessage({ feedback, explanation, explaining, onE
       >
         <Icon name={ok ? "check_circle" : "cancel"} size={32} fill />
       </div>
-      <LatinLabel className="block text-center">{ok ? "Floret" : "Folium lapsum"}</LatinLabel>
       <div
-        className={`font-display text-xl font-semibold text-center mt-1 ${
+        className={`font-display text-xl font-semibold text-center ${
           ok ? "text-sage-deep" : "text-bark"
         }`}
       >

--- a/frontend/src/components/exercises/HintPanel.jsx
+++ b/frontend/src/components/exercises/HintPanel.jsx
@@ -15,7 +15,6 @@ export default function HintPanel({ exercise }) {
         <div className="mb-3">
           <div className="flex items-center gap-2 mb-1">
             <span className="chip chip-sky">{hintLabels[level]}</span>
-            <span className="latin text-[11px]">Suggestio</span>
           </div>
           <p className="text-sm text-bark">{buildHint(exercise, level)}</p>
         </div>

--- a/frontend/src/components/screens/ChildPickerScreen.jsx
+++ b/frontend/src/components/screens/ChildPickerScreen.jsx
@@ -9,7 +9,7 @@ import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
 import Pot from "../ui/Pot"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 const GRADES = ["P1", "P2", "P3", "P4", "P5", "P6"]
 
@@ -69,8 +69,7 @@ export default function ChildPickerScreen() {
     >
       <Page maxWidth="2xl">
         <header className="mb-10">
-          <LatinLabel>Horti nostri</LatinLabel>
-          <Heading level={2} className="mt-1 text-balance">
+          <Heading level={2} className="text-balance">
             Bonjour,{" "}
             <em className="text-sage-deep not-italic font-display italic">
               {user?.display_name || user?.email}
@@ -102,15 +101,15 @@ export default function ChildPickerScreen() {
                   <div className="font-display text-lg text-bark leading-tight">
                     {c.display_name}
                   </div>
-                  <LatinLabel className="block mt-0.5 text-[10px] normal-case tracking-wider">
+                  <span className="block mt-0.5 text-[11px] text-stem tracking-wider">
                     Niveau {c.grade}
-                  </LatinLabel>
+                  </span>
                 </div>
               </Pot>
             </button>
           ))}
           {children.length === 0 && (
-            <p className="col-span-full latin text-center">
+            <p className="col-span-full text-center text-stem italic">
               Aucune plante pour le moment — sème ton premier carnet.
             </p>
           )}
@@ -118,12 +117,7 @@ export default function ChildPickerScreen() {
 
         <Card variant="tag" className="p-6 max-w-xl" data-testid="add-child-form">
           <form onSubmit={onAdd} className="space-y-4">
-            <div>
-              <LatinLabel>Semen novum</LatinLabel>
-              <Heading level={4} className="mt-0.5">
-                Ajouter un profil
-              </Heading>
-            </div>
+            <Heading level={4}>Ajouter un profil</Heading>
             <div className="flex flex-col sm:flex-row gap-3">
               <Input
                 value={name}

--- a/frontend/src/components/screens/DebugInputsScreen.jsx
+++ b/frontend/src/components/screens/DebugInputsScreen.jsx
@@ -57,7 +57,7 @@ export default function DebugInputsScreen() {
         <div className="grid gap-6">
           {samples.map((s, i) => (
             <section key={`${s.input_type}-${i}`} className="flex flex-col items-center gap-2">
-              <div className="latin text-xs uppercase tracking-wide text-stem">
+              <div className="text-xs uppercase tracking-wide text-stem">
                 {s.input_type} · {s.skill_id} · difficulty {s.difficulty}
               </div>
               <ExerciseCard

--- a/frontend/src/components/screens/DiagnosticResult.jsx
+++ b/frontend/src/components/screens/DiagnosticResult.jsx
@@ -4,7 +4,7 @@ import Page from "../layout/Page"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import { downloadDiagnosticPdf } from "../../api/history"
 
 const BUCKET_STYLES = {
@@ -108,10 +108,7 @@ function VerdictHero({ verdict, child, overallPct, totalCorrect, totalAttempts }
         </div>
 
         <div className="flex-1 min-w-0 text-center md:text-left">
-          <LatinLabel>Locus inventus</LatinLabel>
-          <Heading level={2} className="mt-1">
-            {child?.display_name}
-          </Heading>
+          <Heading level={2}>{child?.display_name}</Heading>
           {hasLevel ? (
             <p className="mt-2 text-bark/80">
               <span className="font-semibold">{LEVEL_COPY[verdict.level]}</span>

--- a/frontend/src/components/screens/DiagnosticScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticScreen.jsx
@@ -115,7 +115,6 @@ export default function DiagnosticScreen() {
 
       <ConfirmDialog
         open={confirmQuit}
-        latin="Hortum relinquere"
         title="Quitter le test ?"
         message="Tes réponses seront perdues si tu quittes avant la fin."
         confirmLabel="Quitter"

--- a/frontend/src/components/screens/DrillScreen.jsx
+++ b/frontend/src/components/screens/DrillScreen.jsx
@@ -8,7 +8,7 @@ import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
 import ProgressBar from "../ui/ProgressBar"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import ExerciseCard from "../exercises/ExerciseCard"
 import { useDrillStore } from "../../stores/drillStore"
 import { useAuthStore } from "../../stores/authStore"
@@ -19,8 +19,7 @@ function DrillResult({ summary, bestStreak, onBack }) {
     <AppShell surface="water">
       <div className="flex-1 flex flex-col items-center justify-center p-5 sm:p-6">
       <Card className="p-6 sm:p-8 md:p-10 max-w-md w-full text-center">
-        <LatinLabel>Exercitatio peracta</LatinLabel>
-        <Heading level={2} className="mt-1">Bravo !</Heading>
+        <Heading level={2}>Bravo !</Heading>
 
         <div className="grid grid-cols-3 gap-3 my-8" data-testid="drill-summary">
           <Card className="p-4">

--- a/frontend/src/components/screens/ExamScreen.jsx
+++ b/frontend/src/components/screens/ExamScreen.jsx
@@ -7,7 +7,7 @@ import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import ProgressBar from "../ui/ProgressBar"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import ExerciseCard from "../exercises/ExerciseCard"
 import { useExamStore } from "../../stores/examStore"
 import { useAuthStore } from "../../stores/authStore"
@@ -20,8 +20,7 @@ function ExamResult({ summary, onBack }) {
       <div className="flex-1 flex flex-col items-center justify-center p-5 sm:p-6">
       <Card className="p-6 sm:p-8 md:p-10 max-w-lg w-full">
         <div className="text-center">
-          <LatinLabel>Examinatio peracta</LatinLabel>
-          <Heading level={2} className="mt-1">Résultat</Heading>
+          <Heading level={2}>Résultat</Heading>
 
           <div className="grid grid-cols-2 gap-3 my-6" data-testid="exam-summary">
             <Card className="p-4">
@@ -39,7 +38,7 @@ function ExamResult({ summary, onBack }) {
 
         {breakdown.length > 0 && (
           <div className="mt-4 mb-6" data-testid="exam-breakdown">
-            <LatinLabel className="block mb-2">Detalium</LatinLabel>
+            <Heading level={4} className="mb-2">Détail</Heading>
             <ul className="divide-y divide-bark/5 text-sm">
               {breakdown.map((b) => (
                 <li key={b.index} className="py-2 flex items-center gap-3">

--- a/frontend/src/components/screens/GoogleCallbackScreen.jsx
+++ b/frontend/src/components/screens/GoogleCallbackScreen.jsx
@@ -4,7 +4,7 @@ import { useAuthStore } from "../../stores/authStore"
 import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 export default function GoogleCallbackScreen() {
   const navigate = useNavigate()
@@ -34,20 +34,14 @@ export default function GoogleCallbackScreen() {
       <Card variant="specimen" className="p-6 sm:p-8 text-center max-w-md w-full space-y-5">
         {error ? (
           <>
-            <LatinLabel>Iter interruptum</LatinLabel>
-            <Heading level={3} className="mt-1">
-              {error}
-            </Heading>
+            <Heading level={3}>{error}</Heading>
             <Button onClick={() => navigate("/login", { replace: true })}>
               Retour à la connexion
             </Button>
           </>
         ) : (
           <>
-            <LatinLabel>Ingressus</LatinLabel>
-            <Heading level={3} className="mt-1">
-              Connexion en cours…
-            </Heading>
+            <Heading level={3}>Connexion en cours…</Heading>
             <p className="text-stem">Le jardinier prépare ta serre.</p>
           </>
         )}

--- a/frontend/src/components/screens/LandingScreen.jsx
+++ b/frontend/src/components/screens/LandingScreen.jsx
@@ -4,7 +4,7 @@ import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Logo from "../ui/Logo"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 const ROTATING_WORDS = [
   "sur mesure",
@@ -15,17 +15,14 @@ const ROTATING_WORDS = [
 
 const RITUAL = [
   {
-    latin: "Diagnosis",
     title: "On repère",
     body: "Quelques exercices suffisent à situer l'élève dans l'arbre des compétences.",
   },
   {
-    latin: "Exercitatio",
     title: "On arrose",
     body: "Des exercices choisis par l'IA pour la compétence qui en a besoin.",
   },
   {
-    latin: "Hortus liber",
     title: "On laisse pousser",
     body: "La pratique libre s'adapte, la mémoire s'entretient, la maîtrise vient.",
   },
@@ -113,10 +110,6 @@ function Hero({ onStart, onLogin }) {
         >
           <Logo size="lg" />
         </div>
-        <div className="hero-rise" style={{ animationDelay: "80ms" }}>
-          <LatinLabel>Hortus Mathematicus</LatinLabel>
-        </div>
-
         <Heading
           level={1}
           className="hero-rise mt-4 leading-[1.02] text-4xl sm:text-6xl md:text-7xl"
@@ -195,7 +188,6 @@ function Ritual() {
   return (
     <section className="relative mx-auto max-w-5xl px-6 py-20 sm:px-10 md:py-28">
       <div className="text-center space-y-2 mb-12">
-        <LatinLabel>Modus operandi</LatinLabel>
         <Heading level={2}>Un rituel en trois gestes</Heading>
         <p className="text-stem max-w-xl mx-auto">
           Chaque compétence est une plante. Chaque séance, un geste de jardinier.
@@ -208,15 +200,12 @@ function Ritual() {
             variant="specimen"
             className="p-6 space-y-3"
           >
-            <div className="flex items-center gap-3">
-              <span
-                aria-hidden="true"
-                className="flex h-8 w-8 items-center justify-center rounded-full bg-sage-leaf text-sage-deep font-display text-sm"
-              >
-                {i + 1}
-              </span>
-              <LatinLabel>{step.latin}</LatinLabel>
-            </div>
+            <span
+              aria-hidden="true"
+              className="flex h-8 w-8 items-center justify-center rounded-full bg-sage-leaf text-sage-deep font-display text-sm"
+            >
+              {i + 1}
+            </span>
             <Heading level={4}>{step.title}</Heading>
             <p className="text-stem text-sm leading-relaxed">{step.body}</p>
           </Card>
@@ -230,7 +219,6 @@ function Closer({ onStart }) {
   return (
     <section className="relative mx-auto max-w-3xl px-6 pb-24 sm:px-10 text-center">
       <div className="specimen p-10 space-y-5">
-        <LatinLabel>Ad florem</LatinLabel>
         <Heading level={3}>Prêt à planter la première graine&nbsp;?</Heading>
         <p className="text-stem max-w-xl mx-auto">
           Crée un profil pour ton enfant et laisse le jardin s'occuper du reste.

--- a/frontend/src/components/screens/LoginScreen.jsx
+++ b/frontend/src/components/screens/LoginScreen.jsx
@@ -6,7 +6,7 @@ import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 export default function LoginScreen() {
   const login = useAuthStore((s) => s.login)
@@ -36,10 +36,7 @@ export default function LoginScreen() {
         <Card variant="tag" className="w-full max-w-md p-6 sm:p-8 space-y-5">
           <form onSubmit={onSubmit} data-testid="login-form" className="space-y-5">
             <div>
-              <LatinLabel>Ad hortum redi</LatinLabel>
-              <Heading level={2} className="mt-1">
-                Connexion
-              </Heading>
+              <Heading level={2}>Connexion</Heading>
               <p className="text-sm text-stem mt-1">CollegIA — retourner au jardin.</p>
             </div>
 

--- a/frontend/src/components/screens/ParametresScreen.jsx
+++ b/frontend/src/components/screens/ParametresScreen.jsx
@@ -5,7 +5,7 @@ import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Icon from "../ui/Icon"
 import Input from "../ui/Input"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 const GRADES = ["P1", "P2", "P3", "P4", "P5", "P6"]
 const SAVE_DELAY = 650
@@ -35,7 +35,7 @@ function StatusDot({ state }) {
 
 function AutosaveField({
   label,
-  latinHint,
+  hint,
   value,
   type = "text",
   placeholder,
@@ -91,7 +91,7 @@ function AutosaveField({
   return (
     <label className="block">
       <span className="flex items-center gap-2 text-sm">
-        <span className="latin normal-case text-stem">{latinHint}</span>
+        <span className="text-stem">{hint}</span>
         <StatusDot state={state} />
       </span>
       <Input
@@ -155,7 +155,7 @@ function PasswordDrawer() {
       >
         <form onSubmit={onSubmit} className="mt-4 space-y-3" data-testid="password-form">
           <label className="block">
-            <span className="latin normal-case text-stem text-sm">mot de passe actuel</span>
+            <span className="text-stem text-sm">mot de passe actuel</span>
             <Input
               type="password"
               value={cur}
@@ -166,7 +166,7 @@ function PasswordDrawer() {
             />
           </label>
           <label className="block">
-            <span className="latin normal-case text-stem text-sm">nouveau mot de passe</span>
+            <span className="text-stem text-sm">nouveau mot de passe</span>
             <Input
               type="password"
               value={next}
@@ -178,7 +178,7 @@ function PasswordDrawer() {
             />
           </label>
           <label className="block">
-            <span className="latin normal-case text-stem text-sm">confirmer</span>
+            <span className="text-stem text-sm">confirmer</span>
             <Input
               type="password"
               value={confirm}
@@ -248,14 +248,14 @@ function ChildRow({ child, index }) {
           <div className="flex-1 grid grid-cols-1 sm:grid-cols-[1fr_7rem] gap-3">
             <AutosaveField
               label="Nom"
-              latinHint="nomen"
+              hint="prénom"
               value={child.display_name}
               onSave={(v) => save({ display_name: v })}
               validate={(v) => (!v.trim() ? "Un prénom est requis." : null)}
               testid={`child-name-${child.id}`}
             />
             <label className="block">
-              <span className="latin normal-case text-stem text-sm">niveau</span>
+              <span className="text-stem text-sm">niveau</span>
               <Input
                 as="select"
                 value={child.grade}
@@ -421,28 +421,21 @@ export default function ParametresScreen() {
           >
             <Icon name="arrow_back" size={16} /> Retour
           </button>
-          <LatinLabel>Pavilio</LatinLabel>
         </header>
 
         <div className="mb-10">
-          <LatinLabel>Ratio & cura</LatinLabel>
-          <Heading level={2} className="mt-1">
-            Paramètres
-          </Heading>
+          <Heading level={2}>Paramètres</Heading>
           <p className="text-stem mt-2 text-sm">
             Ton compte, tes jardinières — tout se règle ici.
           </p>
         </div>
 
         <section className="mb-12" data-testid="section-account">
-          <div className="flex items-baseline gap-3 mb-4">
-            <Heading level={4}>Mon carnet</Heading>
-            <LatinLabel className="normal-case text-xs">hortulanus</LatinLabel>
-          </div>
+          <Heading level={4} className="mb-4">Mon carnet</Heading>
           <Card variant="tag" className="p-6 space-y-5">
             <AutosaveField
               label="Nom"
-              latinHint="nomen"
+              hint="prénom"
               value={user?.display_name || ""}
               onSave={(v) => updateUser({ display_name: v })}
               testid="account-display-name"
@@ -450,7 +443,7 @@ export default function ParametresScreen() {
             />
             <AutosaveField
               label="Email"
-              latinHint="courriel"
+              hint="courriel"
               type="email"
               value={user?.email || ""}
               onSave={(v) => updateUser({ email: v })}
@@ -464,10 +457,7 @@ export default function ParametresScreen() {
         </section>
 
         <section data-testid="section-children">
-          <div className="flex items-baseline gap-3 mb-4">
-            <Heading level={4}>Mes jardinières</Heading>
-            <LatinLabel className="normal-case text-xs">horti</LatinLabel>
-          </div>
+          <Heading level={4} className="mb-4">Mes jardinières</Heading>
           <div className="space-y-3">
             {children.map((c, i) => (
               <ChildRow key={c.id} child={c} index={i} />

--- a/frontend/src/components/screens/ParentDashboardScreen.jsx
+++ b/frontend/src/components/screens/ParentDashboardScreen.jsx
@@ -11,7 +11,7 @@ import Card from "../ui/Card"
 import Chip from "../ui/Chip"
 import EmptyState from "../ui/EmptyState"
 import ProgressBar from "../ui/ProgressBar"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 const MODE_LABELS = {
   training: "Entraînement",
@@ -50,7 +50,9 @@ function StudentCard({ student, onOpenDetail }) {
           <Heading level={3} className="text-sage-deep">
             {student.display_name}
           </Heading>
-          <LatinLabel className="block mt-1">Niveau {student.grade}</LatinLabel>
+          <span className="block mt-1 text-xs text-stem uppercase tracking-wider">
+            Niveau {student.grade}
+          </span>
         </div>
         <Button variant="ghost" onClick={() => onOpenDetail(student)}>
           Voir en détail →
@@ -60,7 +62,7 @@ function StudentCard({ student, onOpenDetail }) {
       <div className="grid gap-6 md:grid-cols-3">
         <section className="space-y-3">
           <div className="flex items-center justify-between">
-            <LatinLabel>Hortus · Maîtrise</LatinLabel>
+            <span className="text-xs text-stem uppercase tracking-wider">Maîtrise</span>
             <span className="font-mono text-xs text-stem tabular-nums">
               {m.mastered || 0} / {total}
             </span>
@@ -75,7 +77,7 @@ function StudentCard({ student, onOpenDetail }) {
         </section>
 
         <section>
-          <LatinLabel>Activité récente</LatinLabel>
+          <span className="text-xs text-stem uppercase tracking-wider">Activité récente</span>
           <div className="mt-2 text-sm text-stem">
             7 derniers jours :{" "}
             <span className="text-bark font-medium">{week.attempts}</span> exercices ·{" "}
@@ -114,25 +116,25 @@ function StudentCard({ student, onOpenDetail }) {
         </section>
 
         <section className="space-y-3">
-          <LatinLabel>Progrès</LatinLabel>
+          <span className="text-xs text-stem uppercase tracking-wider">Progrès</span>
           <div className="grid grid-cols-3 gap-2 text-center">
             <div>
               <div className="font-display text-2xl text-sage-deep tabular-nums">
                 {g.xp || 0}
               </div>
-              <div className="latin text-[10px]">XP</div>
+              <div className="text-[10px] text-stem uppercase tracking-wider">XP</div>
             </div>
             <div>
               <div className="font-display text-2xl text-sage-deep tabular-nums">
                 {g.current_streak || 0}
               </div>
-              <div className="latin text-[10px]">série</div>
+              <div className="text-[10px] text-stem uppercase tracking-wider">série</div>
             </div>
             <div>
               <div className="font-display text-2xl text-sage-deep tabular-nums">
                 {g.best_streak || 0}
               </div>
-              <div className="latin text-[10px]">record</div>
+              <div className="text-[10px] text-stem uppercase tracking-wider">record</div>
             </div>
           </div>
           <div>
@@ -189,8 +191,7 @@ export default function ParentDashboardScreen() {
     >
       <Page maxWidth="3xl">
         <header className="mb-10">
-          <LatinLabel>Custos horti</LatinLabel>
-          <Heading level={2} className="mt-1 text-balance">
+          <Heading level={2} className="text-balance">
             Espace parent
             {user?.display_name ? (
               <>
@@ -207,7 +208,7 @@ export default function ParentDashboardScreen() {
           </p>
         </header>
 
-        {isLoading && <p className="latin text-center py-10">Chargement du jardin…</p>}
+        {isLoading && <p className="italic text-center py-10 text-stem">Chargement du jardin…</p>}
         {error && (
           <Card variant="paper" className="p-6 text-rose">
             Impossible de charger les données ({error.message}).

--- a/frontend/src/components/screens/ProfileScreen.jsx
+++ b/frontend/src/components/screens/ProfileScreen.jsx
@@ -4,7 +4,7 @@ import Page from "../layout/Page"
 import TopBar from "../layout/TopBar"
 import { TopBarBack } from "../layout/TopBarActions"
 import Card from "../ui/Card"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import { useAuthStore } from "../../stores/authStore"
 import RankChip from "../xp/RankChip"
 import XPBar from "../xp/XPBar"
@@ -33,17 +33,10 @@ export default function ProfileScreen() {
       }
     >
       <Page maxWidth="lg" className="space-y-6">
-        <div className="flex justify-end">
-          <LatinLabel>Florilegium</LatinLabel>
-        </div>
-
         <Card className="p-6 md:p-8">
           <div className="flex items-center justify-between gap-4 flex-wrap">
             <div>
-              <LatinLabel>Hortulanus</LatinLabel>
-              <Heading level={2} className="mt-1">
-                {child.display_name}
-              </Heading>
+              <Heading level={2}>{child.display_name}</Heading>
               <p className="text-stem mt-1">Niveau {child.grade}</p>
             </div>
             <RankChip rank={child.rank || "curieux"} />
@@ -65,10 +58,7 @@ export default function ProfileScreen() {
 
         <Card className="p-6 md:p-8">
           <div className="mb-4">
-            <LatinLabel>Flores pressi</LatinLabel>
-            <Heading level={3} className="mt-0.5">
-              Mon herbier
-            </Heading>
+            <Heading level={3}>Mon herbier</Heading>
           </div>
           <BadgeGallery earned={child.achievements || []} />
         </Card>

--- a/frontend/src/components/screens/RegisterScreen.jsx
+++ b/frontend/src/components/screens/RegisterScreen.jsx
@@ -6,7 +6,7 @@ import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 
 function scorePassword(pw) {
   if (!pw) return 0
@@ -67,10 +67,7 @@ export default function RegisterScreen() {
       <Card variant="tag" className="w-full max-w-md p-6 sm:p-8 space-y-5">
         <form onSubmit={onSubmit} data-testid="register-form" className="space-y-5">
           <div>
-            <LatinLabel>Novum hortum plantare</LatinLabel>
-            <Heading level={2} className="mt-1">
-              Créer un compte
-            </Heading>
+            <Heading level={2}>Créer un compte</Heading>
             <p className="text-sm text-stem mt-1">Plante ta première graine.</p>
           </div>
 

--- a/frontend/src/components/screens/SessionReviewScreen.jsx
+++ b/frontend/src/components/screens/SessionReviewScreen.jsx
@@ -7,7 +7,7 @@ import { TopBarBack } from "../layout/TopBarActions"
 import Icon from "../ui/Icon"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import { useAuthStore } from "../../stores/authStore"
 import { fetchSession, fetchSessionAttempts } from "../../api/sessions"
 import { downloadDiagnosticPdf } from "../../api/history"
@@ -115,7 +115,7 @@ function AttemptRow({ attempt, index }) {
       {mcqOptions(attempt.exercise_params, attempt.student_answer, attempt.correct_answer)}
       <div className="grid grid-cols-2 gap-3 text-sm mt-3">
         <div>
-          <div className="latin text-[10px]">Réponse de l’élève</div>
+          <div className="text-[10px] text-stem uppercase tracking-wider">Réponse de l’élève</div>
           <div
             className={`font-mono tabular-nums ${ok ? "text-sage-deep" : "text-rose"}`}
             data-testid="student-answer"
@@ -124,7 +124,7 @@ function AttemptRow({ attempt, index }) {
           </div>
         </div>
         <div>
-          <div className="latin text-[10px]">Bonne réponse</div>
+          <div className="text-[10px] text-stem uppercase tracking-wider">Bonne réponse</div>
           <div className="font-mono tabular-nums text-bark">{attempt.correct_answer}</div>
         </div>
       </div>
@@ -228,8 +228,7 @@ export default function SessionReviewScreen() {
         <Card className="p-6 md:p-8">
         <div className="flex items-baseline justify-between gap-3 mb-5">
           <div>
-            <LatinLabel>Sessio</LatinLabel>
-            <Heading level={2} className="mt-1">
+            <Heading level={2}>
               {MODE_LABELS[session.mode] || session.mode}
             </Heading>
             <div className="text-sm text-stem mt-1 font-mono tabular-nums">
@@ -282,7 +281,7 @@ export default function SessionReviewScreen() {
         )}
 
         {attempts.length === 0 ? (
-          <p className="latin text-center py-8">Aucune question enregistrée.</p>
+          <p className="italic text-center py-8 text-stem">Aucune question enregistrée.</p>
         ) : (
           <div data-testid="attempts-list">
             {attempts.map((a, i) => (

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -21,8 +21,7 @@ import Plant from "../ui/Plant"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
-import { LatinLabel } from "../ui/Heading"
-import { levelDescriptions, levelLatin, levelVernacular } from "../../lib/constants"
+import { levelDescriptions, levelVernacular } from "../../lib/constants"
 import { GRADES, buildGraph } from "../../lib/skillTreeLayout"
 import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
 
@@ -46,8 +45,7 @@ function LaneLabel({ data }) {
         style={{ borderLeft: `3px solid ${colors.border}`, width: 130, left: 16 }}
       >
         <div className="font-display font-semibold text-xl text-bark">{grade}</div>
-        <div className="latin text-[10px] mt-0.5">{levelLatin[grade]}</div>
-        <div className="text-[10px] text-stem leading-tight mt-1">
+        <div className="text-[11px] text-stem leading-tight mt-1">
           {levelVernacular[grade]}
         </div>
       </div>
@@ -380,7 +378,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
     return (
       <AppShell surface="plain">
         <div className="flex-1 flex items-center justify-center text-stem">
-          <span className="latin">Germinatio…</span>
+          <span className="italic">Chargement…</span>
         </div>
       </AppShell>
     )
@@ -397,7 +395,6 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
             ← Serre
           </a>
           <div className="hidden lg:block shrink-0 ml-1">
-            <LatinLabel>Hortus mathematicus</LatinLabel>
             <h1 className="font-display font-semibold text-lg text-bark leading-tight">
               Carte des espèces
             </h1>
@@ -677,7 +674,7 @@ function DetailPanel({ skill, state, skillsById, masteryById, onClose, onPractic
     >
       <header className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <div className="latin text-[11px]">
+          <div className="text-[11px] text-stem uppercase tracking-wider">
             {levelDescriptions[skill.grade]} · {skill.grade}
           </div>
           <h2 className="font-display font-semibold text-lg md:text-xl text-bark leading-tight mt-0.5">

--- a/frontend/src/components/screens/WelcomeScreen.jsx
+++ b/frontend/src/components/screens/WelcomeScreen.jsx
@@ -4,7 +4,7 @@ import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
-import { Heading, LatinLabel } from "../ui/Heading"
+import { Heading } from "../ui/Heading"
 import AppShell from "../layout/AppShell"
 import Page from "../layout/Page"
 import TopBar from "../layout/TopBar"
@@ -139,8 +139,7 @@ export default function WelcomeScreen() {
     >
       <Page maxWidth="xl">
         <header className="mb-8">
-          <LatinLabel>Hortus mathematicus</LatinLabel>
-          <Heading level={1} className="mt-1 text-balance">
+          <Heading level={1} className="text-balance">
             Bienvenue dans ta serre,{" "}
             <em className="text-sage-deep not-italic font-display italic">
               {child.display_name}
@@ -217,12 +216,7 @@ export default function WelcomeScreen() {
 
         <section className="mb-6">
           <div className="flex items-center justify-between mb-3">
-            <div>
-              <LatinLabel>Florilegium</LatinLabel>
-              <Heading level={4} className="mt-0.5">
-                Mon herbier
-              </Heading>
-            </div>
+            <Heading level={4}>Mon herbier</Heading>
             <button
               onClick={() => navigate("/profile")}
               className="text-xs font-semibold text-sage-deep hover:underline cursor-pointer"

--- a/frontend/src/components/ui/ConfirmDialog.jsx
+++ b/frontend/src/components/ui/ConfirmDialog.jsx
@@ -1,12 +1,11 @@
 import { useEffect } from "react"
 import Button from "./Button"
 import Card from "./Card"
-import { Heading, LatinLabel } from "./Heading"
+import { Heading } from "./Heading"
 
 export default function ConfirmDialog({
   open,
   title = "Confirmer",
-  latin,
   message,
   confirmLabel = "Confirmer",
   cancelLabel = "Annuler",
@@ -43,8 +42,7 @@ export default function ConfirmDialog({
         className="p-6 sm:p-7 max-w-sm w-full text-center"
         onClick={(e) => e.stopPropagation()}
       >
-        {latin && <LatinLabel>{latin}</LatinLabel>}
-        <Heading level={3} className="mt-1" id="confirm-dialog-title">
+        <Heading level={3} id="confirm-dialog-title">
           {title}
         </Heading>
         {message && <p className="text-sm text-stem mt-3">{message}</p>}

--- a/frontend/src/components/ui/Floraison.jsx
+++ b/frontend/src/components/ui/Floraison.jsx
@@ -1,8 +1,8 @@
 import { useEffect } from "react"
 import Button from "./Button"
-import { Heading, LatinLabel } from "./Heading"
+import { Heading } from "./Heading"
 
-export default function Floraison({ title = "Floraison", latin = "Florens", subtitle, onClose }) {
+export default function Floraison({ title = "Floraison", subtitle, onClose }) {
   useEffect(() => {
     const onKey = (e) => {
       if (e.key === "Escape") onClose?.()
@@ -46,8 +46,7 @@ export default function Floraison({ title = "Floraison", latin = "Florens", subt
             strokeLinecap="round"
           />
         </svg>
-        <LatinLabel className="mt-4 inline-block">{latin}</LatinLabel>
-        <Heading level={1} className="mt-2">
+        <Heading level={1} className="mt-4">
           {title}
         </Heading>
         {subtitle && <p className="text-stem mt-3">{subtitle}</p>}

--- a/frontend/src/components/ui/Heading.jsx
+++ b/frontend/src/components/ui/Heading.jsx
@@ -15,12 +15,4 @@ export function Heading({ level = 1, className = "", children, as, ...rest }) {
   )
 }
 
-export function LatinLabel({ className = "", children, ...rest }) {
-  return (
-    <span className={`latin text-xs tracking-wider ${className}`} {...rest}>
-      {children}
-    </span>
-  )
-}
-
 export default Heading

--- a/frontend/src/components/ui/SkillListView.jsx
+++ b/frontend/src/components/ui/SkillListView.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react"
 import { GRADES, GRADE_COLORS } from "../../lib/skillTreeLayout"
-import { levelDescriptions, levelLatin, levelVernacular } from "../../lib/constants"
+import { levelDescriptions, levelVernacular } from "../../lib/constants"
 import { SENTIER_LABEL, SENTIER_DOT } from "../../lib/skillStatus"
 
 const STATE_LABEL = SENTIER_LABEL
@@ -71,7 +71,6 @@ export default function SkillListView({
               >
                 {grade}
               </h2>
-              <span className="latin text-[11px]">{levelLatin[grade]}</span>
               <span className="text-[11px] text-stem ml-auto">
                 {levelDescriptions[grade]} · {levelVernacular[grade]}
               </span>
@@ -107,7 +106,7 @@ export default function SkillListView({
                           )}
                           <span className="truncate">{d.label}</span>
                         </span>
-                        <span className="block latin text-[10px] mt-0.5">
+                        <span className="block text-[11px] text-stem mt-0.5">
                           {d.family} · {STATE_LABEL[state]}
                           {attempts > 0 ? ` · ${pct}%` : ""}
                         </span>

--- a/frontend/src/lib/constants.js
+++ b/frontend/src/lib/constants.js
@@ -9,15 +9,6 @@ export const levelDescriptions = {
   P6: "6ème primaire",
 }
 
-export const levelLatin = {
-  P1: "Sementes",
-  P2: "Germinatio",
-  P3: "Folia",
-  P4: "Flores",
-  P5: "Fructus",
-  P6: "Messis",
-}
-
 export const levelVernacular = {
   P1: "Semis",
   P2: "Pousses",


### PR DESCRIPTION
## Summary
- Strip every Latin flourish (Hortus Mathematicus, Modus operandi, Florilegium, Hortulanus, etc.) from Landing, Welcome, SkillTree, ChildPicker, Login, Register, GoogleCallback, Drill, Exam, Diagnostic/DiagnosticResult, ParentDashboard, Profile, Parametres, SessionReview, ExerciseCard, FeedbackMessage, HintPanel, Floraison, ConfirmDialog, BadgeToast, SkillListView, DebugInputs.
- Delete the `LatinLabel` component, the `.latin` CSS class, and the unused `levelLatin` constant; drop `latin` prop from `Floraison` + `ConfirmDialog`.
- Update CLAUDE.md design section and `design/DESIGN.md` to stop mentioning Latin labels / Hortus Mathematicus.
- French/English UI text kept. Fraunces italic still used for display accents.

Closes #154.

## Test plan
- [ ] Click through Landing, Login, Register, ChildPicker, Welcome, SkillTree, Diagnostic result, Drill result, Exam result, Profile, Parametres, ParentDashboard, SessionReview — no Latin strings anywhere
- [ ] `npm run lint` passes
- [ ] Playwright auth + smoke specs still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)