### PR TITLE
feat(#153): botanical Loader component for loading screens

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -20,19 +20,28 @@ import SessionReviewScreen from "./components/screens/SessionReviewScreen"
 import ParentDashboardScreen from "./components/screens/ParentDashboardScreen"
 import ParametresScreen from "./components/screens/ParametresScreen"
 import BadgeToast from "./components/badges/BadgeToast"
+import Loader from "./components/ui/Loader"
 import "./App.css"
+
+function BootLoader() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-chalk">
+      <Loader message="Chargement…" size="lg" />
+    </div>
+  )
+}
 
 function RequireAuth({ children }) {
   const { user, loading } = useAuthStore()
   const location = useLocation()
-  if (loading && !user) return <div className="p-8 text-center">Chargement…</div>
+  if (loading && !user) return <BootLoader />
   if (!user) return <Navigate to="/login" replace state={{ from: location }} />
   return children
 }
 
 function RootRoute() {
   const { user, loading } = useAuthStore()
-  if (loading && !user) return <div className="p-8 text-center">Chargement…</div>
+  if (loading && !user) return <BootLoader />
   return user ? <WelcomeScreen /> : <LandingScreen />
 }
 

--- a/frontend/src/components/exercises/ExerciseCard.jsx
+++ b/frontend/src/components/exercises/ExerciseCard.jsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from "react"
 import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
+import Loader from "../ui/Loader"
 import HintPanel from "./HintPanel"
 import FeedbackMessage from "./FeedbackMessage"
 import NumberInput from "./inputs/NumberInput"
@@ -47,8 +48,8 @@ export default function ExerciseCard({
 
   if (!exercise) {
     return (
-      <Card className="p-8 w-full max-w-md text-center">
-        <span className="italic text-stem">Chargement…</span>
+      <Card className="p-8 w-full max-w-md">
+        <Loader message="Chargement…" />
       </Card>
     )
   }

--- a/frontend/src/components/screens/DebugInputsScreen.jsx
+++ b/frontend/src/components/screens/DebugInputsScreen.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router"
 import AppShell from "../layout/AppShell"
 import Page from "../layout/Page"
 import { api } from "../../api/client"
+import Loader from "../ui/Loader"
 import ExerciseCard from "../exercises/ExerciseCard"
 
 export default function DebugInputsScreen() {
@@ -51,7 +52,11 @@ export default function DebugInputsScreen() {
           </div>
         </div>
 
-        {loading && <p className="text-center text-stem">Chargement…</p>}
+        {loading && (
+          <div className="py-10">
+            <Loader message="Chargement…" />
+          </div>
+        )}
         {error && <p className="text-center text-rose">Erreur : {error}</p>}
 
         <div className="grid gap-6">

--- a/frontend/src/components/screens/DiagnosticReviewScreen.jsx
+++ b/frontend/src/components/screens/DiagnosticReviewScreen.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react"
 import { useNavigate, useParams, useSearchParams } from "react-router"
 import AppShell from "../layout/AppShell"
+import Loader from "../ui/Loader"
 import { diagnosticApi } from "../../api/diagnostic"
 import { useAuthStore } from "../../stores/authStore"
 import DiagnosticResult from "./DiagnosticResult"
@@ -48,9 +49,7 @@ export default function DiagnosticReviewScreen() {
   if (!result) {
     return (
       <AppShell surface="greenhouse">
-        <div className="flex-1 flex items-center justify-center p-6 text-stem">
-          Chargement du test de niveau…
-        </div>
+        <Loader message="Chargement du test de niveau…" size="lg" variant="page" />
       </AppShell>
     )
   }

--- a/frontend/src/components/screens/HistoryScreen.jsx
+++ b/frontend/src/components/screens/HistoryScreen.jsx
@@ -8,6 +8,7 @@ import Icon from "../ui/Icon"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import EmptyState from "../ui/EmptyState"
+import Loader from "../ui/Loader"
 import { Heading } from "../ui/Heading"
 import { useAuthStore } from "../../stores/authStore"
 import {
@@ -185,7 +186,9 @@ export default function HistoryScreen() {
         )}
 
         {rows === null && !error && (
-          <div className="text-stem text-sm">Chargement…</div>
+          <div className="py-10">
+            <Loader message="Chargement de l’historique…" />
+          </div>
         )}
 
         {rows && rows.length === 0 && (

--- a/frontend/src/components/screens/ParentDashboardScreen.jsx
+++ b/frontend/src/components/screens/ParentDashboardScreen.jsx
@@ -10,6 +10,7 @@ import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
 import EmptyState from "../ui/EmptyState"
+import Loader from "../ui/Loader"
 import ProgressBar from "../ui/ProgressBar"
 import { Heading } from "../ui/Heading"
 
@@ -208,7 +209,11 @@ export default function ParentDashboardScreen() {
           </p>
         </header>
 
-        {isLoading && <p className="italic text-center py-10 text-stem">Chargement du jardin…</p>}
+        {isLoading && (
+          <div className="py-10">
+            <Loader message="Chargement du jardin…" />
+          </div>
+        )}
         {error && (
           <Card variant="paper" className="p-6 text-rose">
             Impossible de charger les données ({error.message}).

--- a/frontend/src/components/screens/SessionReviewScreen.jsx
+++ b/frontend/src/components/screens/SessionReviewScreen.jsx
@@ -7,6 +7,7 @@ import { TopBarBack } from "../layout/TopBarActions"
 import Icon from "../ui/Icon"
 import Card from "../ui/Card"
 import Chip from "../ui/Chip"
+import Loader from "../ui/Loader"
 import { Heading } from "../ui/Heading"
 import { useAuthStore } from "../../stores/authStore"
 import { fetchSession, fetchSessionAttempts } from "../../api/sessions"
@@ -199,9 +200,7 @@ export default function SessionReviewScreen() {
   if (!session || !attempts) {
     return (
       <AppShell surface="greenhouse">
-        <div className="flex-1 flex items-center justify-center p-6 text-stem">
-          Chargement de la session…
-        </div>
+        <Loader message="Chargement de la session…" size="lg" variant="page" />
       </AppShell>
     )
   }

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -21,6 +21,7 @@ import Plant from "../ui/Plant"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
+import Loader from "../ui/Loader"
 import { levelDescriptions, levelVernacular } from "../../lib/constants"
 import { GRADES, buildGraph } from "../../lib/skillTreeLayout"
 import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
@@ -377,9 +378,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
   if (isLoading) {
     return (
       <AppShell surface="plain">
-        <div className="flex-1 flex items-center justify-center text-stem">
-          <span className="italic">Chargement…</span>
-        </div>
+        <Loader message="Chargement de la carte…" size="lg" variant="page" />
       </AppShell>
     )
   }

--- a/frontend/src/components/ui/Loader.jsx
+++ b/frontend/src/components/ui/Loader.jsx
@@ -1,0 +1,156 @@
+const SIZES = {
+  sm: { plant: 56, gap: "gap-2", label: "text-xs" },
+  md: { plant: 88, gap: "gap-3", label: "text-sm" },
+  lg: { plant: 128, gap: "gap-4", label: "text-base" },
+}
+
+export default function Loader({
+  message = "Chargement…",
+  size = "md",
+  variant = "inline",
+  className = "",
+}) {
+  const { plant, gap, label } = SIZES[size] ?? SIZES.md
+  const height = Math.round(plant * (140 / 120))
+
+  const content = (
+    <div
+      className={`jardin-loader flex flex-col items-center justify-center ${gap} ${className}`}
+      role="status"
+      aria-live="polite"
+    >
+      <svg
+        viewBox="0 0 120 140"
+        width={plant}
+        height={height}
+        aria-hidden="true"
+        className="overflow-visible"
+      >
+        <defs>
+          <radialGradient id="jardin-halo" cx="50%" cy="55%" r="55%">
+            <stop offset="0%" stopColor="#C7E0B5" stopOpacity="0.55" />
+            <stop offset="100%" stopColor="#C7E0B5" stopOpacity="0" />
+          </radialGradient>
+        </defs>
+
+        <circle cx="60" cy="80" r="54" fill="url(#jardin-halo)" className="loader-halo" />
+
+        <g className="loader-drops">
+          <path d="M60 6 Q 63 13 60 18 Q 57 13 60 6 Z" fill="#4F8BAC" opacity="0.75" className="loader-drop loader-drop-1" />
+          <path d="M44 14 Q 46.6 20 44 24 Q 41.4 20 44 14 Z" fill="#4F8BAC" opacity="0.6" className="loader-drop loader-drop-2" />
+          <path d="M76 12 Q 78.6 18 76 22 Q 73.4 18 76 12 Z" fill="#4F8BAC" opacity="0.6" className="loader-drop loader-drop-3" />
+        </g>
+
+        <g className="loader-plant" style={{ transformOrigin: "60px 102px" }}>
+          <path
+            d="M60 102 Q 60 86 60 70"
+            stroke="#3F6F4A"
+            strokeWidth="2.4"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <g className="loader-leaf loader-leaf-left" style={{ transformOrigin: "60px 82px" }}>
+            <ellipse
+              cx="44"
+              cy="74"
+              rx="14"
+              ry="6.5"
+              fill="#C7E0B5"
+              stroke="#3F6F4A"
+              strokeWidth="1.4"
+              transform="rotate(-24 44 74)"
+            />
+            <path
+              d="M58 76 Q 50 74 34 72"
+              stroke="#3F6F4A"
+              strokeWidth="1"
+              fill="none"
+              strokeLinecap="round"
+              opacity="0.7"
+            />
+          </g>
+          <g className="loader-leaf loader-leaf-right" style={{ transformOrigin: "60px 82px" }}>
+            <ellipse
+              cx="76"
+              cy="74"
+              rx="14"
+              ry="6.5"
+              fill="#C7E0B5"
+              stroke="#3F6F4A"
+              strokeWidth="1.4"
+              transform="rotate(24 76 74)"
+            />
+            <path
+              d="M62 76 Q 70 74 86 72"
+              stroke="#3F6F4A"
+              strokeWidth="1"
+              fill="none"
+              strokeLinecap="round"
+              opacity="0.7"
+            />
+          </g>
+          <circle cx="60" cy="68" r="3.2" fill="#E8A6A1" stroke="#B7615C" strokeWidth="1.1" className="loader-bud" />
+        </g>
+
+        <g className="loader-pot">
+          <path
+            d="M40 104 L 43 130 Q 43 134 47 134 L 73 134 Q 77 134 77 130 L 80 104 Z"
+            fill="#D8B48A"
+            stroke="#8A6A4A"
+            strokeWidth="1.4"
+            strokeLinejoin="round"
+          />
+          <path d="M40 104 L 80 104" stroke="#8A6A4A" strokeWidth="1.4" strokeLinecap="round" />
+          <ellipse cx="60" cy="104" rx="18" ry="3" fill="#5C4327" opacity="0.25" />
+        </g>
+      </svg>
+
+      {message ? (
+        <p className={`text-stem font-display italic ${label}`}>{message}</p>
+      ) : null}
+
+      <style>{`
+        @keyframes jardin-sway {
+          0%, 100% { transform: rotate(-2.4deg); }
+          50%      { transform: rotate(2.4deg); }
+        }
+        @keyframes jardin-leaf-left {
+          0%, 100% { transform: rotate(0deg); }
+          50%      { transform: rotate(-5deg); }
+        }
+        @keyframes jardin-leaf-right {
+          0%, 100% { transform: rotate(0deg); }
+          50%      { transform: rotate(5deg); }
+        }
+        @keyframes jardin-bud {
+          0%, 100% { transform: scale(1); }
+          50%      { transform: scale(1.15); }
+        }
+        @keyframes jardin-drop {
+          0%   { transform: translateY(-10px); opacity: 0; }
+          15%  { opacity: 0.85; }
+          70%  { opacity: 0.85; }
+          90%  { transform: translateY(50px); opacity: 0; }
+          100% { transform: translateY(50px); opacity: 0; }
+        }
+        @keyframes jardin-halo {
+          0%, 100% { opacity: 0.55; transform: scale(1); }
+          50%      { opacity: 0.9;  transform: scale(1.06); }
+        }
+        .jardin-loader .loader-plant     { animation: jardin-sway 3.4s ease-in-out infinite; }
+        .jardin-loader .loader-leaf-left { animation: jardin-leaf-left 2.8s ease-in-out infinite; }
+        .jardin-loader .loader-leaf-right{ animation: jardin-leaf-right 2.8s ease-in-out infinite; }
+        .jardin-loader .loader-bud       { animation: jardin-bud 2.4s ease-in-out infinite; transform-origin: 60px 68px; transform-box: fill-box; }
+        .jardin-loader .loader-halo      { animation: jardin-halo 3.4s ease-in-out infinite; transform-origin: 60px 80px; transform-box: fill-box; }
+        .jardin-loader .loader-drop-1    { animation: jardin-drop 2.2s ease-in 0s    infinite; }
+        .jardin-loader .loader-drop-2    { animation: jardin-drop 2.2s ease-in 0.55s infinite; }
+        .jardin-loader .loader-drop-3    { animation: jardin-drop 2.2s ease-in 1.1s  infinite; }
+      `}</style>
+    </div>
+  )
+
+  if (variant === "page") {
+    return <div className="flex-1 flex items-center justify-center p-6">{content}</div>
+  }
+  return content
+}


### PR DESCRIPTION
## Summary
- New `Loader` component (`frontend/src/components/ui/Loader.jsx`) — a botanical loading animation in the JARDIN palette: swaying sprout in a terracotta pot, flowing leaves, pulsing bud, and three staggered water droplets falling from above.
- Three sizes (`sm` / `md` / `lg`) and two variants (`inline` / `page`), with an optional French caption in italic Fraunces. `role="status"` + `aria-live="polite"`, and the existing global `prefers-reduced-motion` guard in `index.css` kills animation duration for users who ask for it.
- Swapped it in at every bare "Chargement…" / "Germinatio…" call site: auth bootstrap (App.jsx), Carte (SkillTree), Historique, Dashboard parent, review du test de niveau, review de session, carte d'exercice, et écran de debug.

Resolves #153.

## Test plan
- [ ] `docker compose up -d` then throttle network in DevTools and visit `/skill-tree`, `/history`, `/dashboard`, `/history/session/:id`, `/history/diagnostic/:id` — loader appears and animates.
- [ ] Log out and in to see the full-screen bootstrap Loader.
- [ ] Check `prefers-reduced-motion: reduce` in DevTools — animations disabled, SVG stays on screen statically.
- [ ] Playwright e2e suite stays green.

## Notes
Overlaps lightly with PR #161 (`feat/154-remove-latin-labels`): this PR removes the `.latin`/`Germinatio…` text from the loading states as a side effect of replacing them with `<Loader>`, but leaves every other `LatinLabel` / `latin` usage untouched for #161 to own. Whichever lands second will get a trivial merge resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)