### PR TITLE
feat(#165): gate /debug/inputs behind DEV mode

### DIFF
--- a/backend/apps/exercises/views.py
+++ b/backend/apps/exercises/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core import signing
 from django.http import Http404
 from django.shortcuts import get_object_or_404
@@ -75,6 +76,8 @@ def next_exercise(request):
 @permission_classes([IsAuthenticated])
 def samples(request):
     """Debug-only: one generated exercise per input_type, with a valid signature."""
+    if not settings.DEBUG and not request.user.is_staff:
+        raise Http404
     out = []
     for input_type, _ in INPUT_TYPES:
         tpl = ExerciseTemplate.objects.filter(input_type=input_type).order_by("?").first()

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -76,7 +76,9 @@ export default function App() {
         <Route path="/history" element={<RequireAuth><HistoryScreen /></RequireAuth>} />
         <Route path="/history/diagnostic/:sessionId" element={<RequireAuth><DiagnosticReviewScreen /></RequireAuth>} />
         <Route path="/history/session/:sessionId" element={<RequireAuth><SessionReviewScreen /></RequireAuth>} />
-        <Route path="/debug/inputs" element={<RequireAuth><DebugInputsScreen /></RequireAuth>} />
+        {import.meta.env.DEV && (
+          <Route path="/debug/inputs" element={<RequireAuth><DebugInputsScreen /></RequireAuth>} />
+        )}
       </Routes>
     </>
   )


### PR DESCRIPTION
## Summary
- Wrap the `/debug/inputs` SPA route in `import.meta.env.DEV` so it only registers in dev builds.
- Make `/api/exercises/samples/` raise `Http404` when `settings.DEBUG` is False and the user isn't staff.

Closes #165.

## Test plan
- [ ] Local dev (`DEBUG=True`): `/debug/inputs` still renders every input type; `GET /api/exercises/samples/` as a regular parent still returns 200.
- [ ] Prod (`DEBUG=False`): `GET /api/exercises/samples/` as an authenticated non-staff parent returns 404; `/debug/inputs` hits the SPA 404 screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)