### PR TITLE
feat(#171): animated plants + botanical 404 page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,6 +14,8 @@ import DrillScreen from "./components/screens/DrillScreen"
 import ExamScreen from "./components/screens/ExamScreen"
 import ProfileScreen from "./components/screens/ProfileScreen"
 import DebugInputsScreen from "./components/screens/DebugInputsScreen"
+import DebugPlantsScreen from "./components/screens/DebugPlantsScreen"
+import NotFoundScreen from "./components/screens/NotFoundScreen"
 import HistoryScreen from "./components/screens/HistoryScreen"
 import DiagnosticReviewScreen from "./components/screens/DiagnosticReviewScreen"
 import SessionReviewScreen from "./components/screens/SessionReviewScreen"
@@ -79,6 +81,10 @@ export default function App() {
         {import.meta.env.VITE_ENVIRONMENT === "dev" && (
           <Route path="/debug/inputs" element={<RequireAuth><DebugInputsScreen /></RequireAuth>} />
         )}
+        {import.meta.env.VITE_ENVIRONMENT === "dev" && (
+          <Route path="/debug/plants" element={<RequireAuth><DebugPlantsScreen /></RequireAuth>} />
+        )}
+        <Route path="*" element={<NotFoundScreen />} />
       </Routes>
     </>
   )

--- a/frontend/src/components/screens/DebugPlantsScreen.jsx
+++ b/frontend/src/components/screens/DebugPlantsScreen.jsx
@@ -1,0 +1,286 @@
+import { useEffect, useState } from "react"
+import { Link } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import Plant from "../ui/Plant"
+import {
+  AnimatedSeed,
+  AnimatedSprout,
+  AnimatedBud,
+  AnimatedFlower,
+  AnimatedWilted,
+  PlantKeyframes,
+} from "../ui/PlantAnimated"
+
+const STATES = [
+  {
+    id: "locked",
+    label: "Graine",
+    tag: "en sommeil",
+    latin: "Semen dormiens",
+    staticStatus: "locked",
+    Comp: AnimatedSeed,
+    legacyMastery: 0,
+    note: "Enveloppée, elle respire lentement. Une fissure dorée pulse — la promesse d'un départ.",
+  },
+  {
+    id: "in_progress",
+    label: "Pousse",
+    tag: "en éveil",
+    latin: "Plantula vivax",
+    staticStatus: "in_progress",
+    Comp: AnimatedSprout,
+    legacyMastery: 0.2,
+    note: "Deux cotylédons déplient leurs premières feuilles ; la sève cherche la lumière d'un balancement curieux.",
+  },
+  {
+    id: "bud",
+    label: "Bouton",
+    tag: "en croissance",
+    latin: "Gemma parata",
+    staticStatus: "in_progress",
+    Comp: AnimatedBud,
+    legacyMastery: 0.6,
+    note: "La tige s'élance et retient son bouton comme une promesse. Une goutte tombe, un feuillage frémit.",
+  },
+  {
+    id: "done",
+    label: "Floraison",
+    tag: "épanouie",
+    latin: "Floritura plena",
+    staticStatus: "completed",
+    Comp: AnimatedFlower,
+    legacyMastery: 1,
+    note: "Corolle ouverte, pollen qui s'élève, halo miel — la floraison respire à huit pétales, chacun à son tempo.",
+  },
+  {
+    id: "wilted",
+    label: "Fanée",
+    tag: "à arroser",
+    latin: "Planta sitiens",
+    staticStatus: "review",
+    Comp: AnimatedWilted,
+    legacyMastery: 0.4,
+    note: "Le port s'incline, les feuilles grisonnent. Une goutte bleue hésite au-dessus — il suffit d'un soin.",
+  },
+]
+
+function Toggle({ active, onChange, children }) {
+  return (
+    <button
+      onClick={onChange}
+      className={`navlink ${active ? "active" : ""}`}
+      aria-pressed={active}
+    >
+      {children}
+    </button>
+  )
+}
+
+function SpecimenCard({ state, options, index }) {
+  const { Comp, label, tag, latin, note } = state
+  return (
+    <article
+      className={`specimen relative flex flex-col items-stretch ${
+        options.paused ? "jp-paused" : ""
+      }`}
+      style={{ animationDelay: `${index * 60}ms` }}
+    >
+      <div className="absolute top-3 left-4 text-[10px] font-mono tracking-[0.18em] uppercase text-twig">
+        No {String(index + 1).padStart(2, "0")}
+      </div>
+      <div className="pt-8 pb-3 flex justify-center">
+        <div className="w-40 h-48 flex items-center justify-center">
+          <Comp pot={options.pot} halo={options.halo} />
+        </div>
+      </div>
+      <div className="border-t border-dashed border-bark/10 px-4 py-3 bg-chalk/60 rounded-b-[0.875rem]">
+        <div className="flex items-baseline justify-between gap-2">
+          <h3 className="font-display italic text-xl text-bark">{label}</h3>
+          <span className="text-[10px] uppercase tracking-[0.16em] text-stem">{tag}</span>
+        </div>
+        <div className="font-mono text-[11px] text-twig mt-0.5">{latin}</div>
+        <p className="text-xs text-stem mt-2 leading-relaxed">{note}</p>
+      </div>
+    </article>
+  )
+}
+
+function ComparePanel({ title, children, muted }) {
+  return (
+    <div
+      className={`specimen flex flex-col ${
+        muted ? "bg-chalk/70" : "bg-bone"
+      }`}
+    >
+      <div className="px-4 pt-3 pb-2 flex items-center justify-between border-b border-dashed border-bark/10">
+        <span className="text-[10px] font-mono tracking-[0.18em] uppercase text-stem">{title}</span>
+        <span
+          className={`text-[10px] font-mono px-2 py-0.5 rounded-full ${
+            muted ? "bg-mist text-stem" : "bg-sage-pale text-sage-deep"
+          }`}
+        >
+          {muted ? "prod" : "debug"}
+        </span>
+      </div>
+      <div className="flex-1 flex items-center justify-center py-8">{children}</div>
+    </div>
+  )
+}
+
+export default function DebugPlantsScreen() {
+  const [halo, setHalo] = useState(true)
+  const [pot, setPot] = useState(true)
+  const [paused, setPaused] = useState(false)
+  const [compareId, setCompareId] = useState("done")
+  const [cycleIdx, setCycleIdx] = useState(0)
+  const [auto, setAuto] = useState(true)
+
+  useEffect(() => {
+    if (!auto || paused) return
+    const t = setInterval(() => setCycleIdx((i) => (i + 1) % STATES.length), 3800)
+    return () => clearInterval(t)
+  }, [auto, paused])
+
+  const options = { halo, pot, paused }
+  const hero = STATES[cycleIdx]
+  const HeroComp = hero.Comp
+  const compare = STATES.find((s) => s.id === compareId) ?? STATES[0]
+
+  return (
+    <AppShell surface="grid">
+      <PlantKeyframes />
+      <Page maxWidth="3xl">
+        <header className="mb-8 flex items-start justify-between flex-wrap gap-4">
+          <div>
+            <div className="text-[11px] tracking-[0.24em] uppercase text-stem font-mono">
+              Planche n° 7 · Laboratoire
+            </div>
+            <h1 className="font-display italic text-4xl md:text-5xl font-semibold text-bark leading-[1.05] mt-1">
+              Observatoire <br className="hidden md:block" />
+              botanique
+            </h1>
+            <p className="font-display italic text-stem text-lg mt-2">
+              cinq états · cinq respirations
+            </p>
+          </div>
+          <div className="flex gap-2">
+            <Link to="/skill-tree" className="navlink">Carte</Link>
+            <Link to="/" className="navlink">Retour</Link>
+          </div>
+        </header>
+
+        <section
+          className={`specimen mb-10 overflow-hidden grid md:grid-cols-[1fr,auto] gap-4 ${
+            paused ? "jp-paused" : ""
+          }`}
+        >
+          <div className="p-6 md:p-8 flex flex-col justify-between">
+            <div>
+              <div className="text-[10px] font-mono tracking-[0.22em] uppercase text-stem mb-2">
+                Chronologie de floraison
+              </div>
+              <h2 className="font-display italic text-3xl md:text-4xl text-bark">
+                {hero.label}{" "}
+                <span className="text-stem text-xl">— {hero.tag}</span>
+              </h2>
+              <div className="font-mono text-xs text-twig mt-1">{hero.latin}</div>
+              <p className="text-stem text-sm leading-relaxed mt-4 max-w-md">{hero.note}</p>
+            </div>
+            <div className="mt-6 flex items-center gap-3 flex-wrap">
+              <div className="flex items-center gap-1.5">
+                {STATES.map((s, i) => (
+                  <button
+                    key={s.id}
+                    onClick={() => {
+                      setAuto(false)
+                      setCycleIdx(i)
+                    }}
+                    aria-label={s.label}
+                    className={`h-2 rounded-full transition-all ${
+                      i === cycleIdx ? "w-6 bg-sage-deep" : "w-2 bg-sage-pale hover:bg-sage-soft"
+                    }`}
+                  />
+                ))}
+              </div>
+              <button
+                onClick={() => setAuto((v) => !v)}
+                className={`navlink ${auto ? "active" : ""}`}
+              >
+                {auto ? "▶ défile" : "▶ lancer"}
+              </button>
+            </div>
+          </div>
+          <div className="bg-mist/50 flex items-center justify-center px-8 py-10 md:py-6 md:pr-10 md:pl-0">
+            <div className="w-56 h-72 md:w-64 md:h-80 flex items-center justify-center">
+              <HeroComp pot={pot} halo={halo} />
+            </div>
+          </div>
+        </section>
+
+        <section className="mb-4 flex flex-wrap items-center gap-2">
+          <span className="text-[10px] font-mono tracking-[0.22em] uppercase text-stem mr-2">
+            Réglages
+          </span>
+          <Toggle active={halo} onChange={() => setHalo((v) => !v)}>Halo</Toggle>
+          <Toggle active={pot} onChange={() => setPot((v) => !v)}>Pot</Toggle>
+          <Toggle active={!paused} onChange={() => setPaused((v) => !v)}>
+            {paused ? "Figé" : "Animé"}
+          </Toggle>
+          <div className="ml-auto text-[11px] font-mono text-twig">
+            /debug/plants · dev-only
+          </div>
+        </section>
+
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4 mb-12">
+          {STATES.map((s, i) => (
+            <SpecimenCard key={s.id} state={s} options={options} index={i} />
+          ))}
+        </section>
+
+        <section className="mb-16">
+          <div className="flex items-baseline justify-between flex-wrap gap-3 mb-4">
+            <h2 className="font-display italic text-2xl text-bark">
+              Avant <span className="text-stem">·</span> Après
+            </h2>
+            <div className="flex gap-1.5">
+              {STATES.map((s) => (
+                <button
+                  key={s.id}
+                  onClick={() => setCompareId(s.id)}
+                  className={`text-[11px] font-mono px-2.5 py-1 rounded-full transition-colors ${
+                    compareId === s.id
+                      ? "bg-bark text-paper"
+                      : "bg-mist text-stem hover:bg-sage-pale"
+                  }`}
+                >
+                  {s.label.toLowerCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className={`grid grid-cols-1 md:grid-cols-2 gap-4 ${paused ? "jp-paused" : ""}`}>
+            <ComparePanel title="Plant.jsx · statique" muted>
+              <Plant
+                status={compare.staticStatus}
+                mastery={compare.legacyMastery}
+                size={110}
+              />
+            </ComparePanel>
+            <ComparePanel title="PlantAnimated.jsx · vivant">
+              <div className="w-40 h-48">
+                <compare.Comp pot={pot} halo={halo} />
+              </div>
+            </ComparePanel>
+          </div>
+        </section>
+
+        <footer className="text-[11px] font-mono text-twig text-center pb-4">
+          Réservé au développement. Bascule le pot, le halo, ou fige les animations.
+          <br />
+          Inspiration : <code className="text-stem">components/ui/Loader.jsx</code>.
+        </footer>
+      </Page>
+    </AppShell>
+  )
+}

--- a/frontend/src/components/screens/NotFoundScreen.jsx
+++ b/frontend/src/components/screens/NotFoundScreen.jsx
@@ -1,0 +1,161 @@
+import { Link } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import AnimatedPlant, { PlantKeyframes } from "../ui/PlantAnimated"
+
+function DriftingLeaf({ className, style }) {
+  return (
+    <svg
+      viewBox="0 0 48 24"
+      className={`absolute pointer-events-none ${className}`}
+      style={style}
+      aria-hidden="true"
+    >
+      <ellipse cx="24" cy="12" rx="20" ry="7.5" fill="#C7E0B5" stroke="#3F6F4A" strokeWidth="1.2" />
+      <path
+        d="M4 12 Q 24 10 44 12"
+        stroke="#3F6F4A"
+        strokeWidth="0.8"
+        fill="none"
+        strokeLinecap="round"
+        opacity="0.6"
+      />
+    </svg>
+  )
+}
+
+function Spore({ style }) {
+  return (
+    <span
+      className="spore absolute block rounded-full bg-sage-leaf/60 pointer-events-none"
+      style={style}
+      aria-hidden="true"
+    />
+  )
+}
+
+export default function NotFoundScreen() {
+  return (
+    <AppShell surface="greenhouse">
+      <PlantKeyframes />
+      <Page maxWidth="2xl">
+        <section className="relative flex flex-col items-center justify-center py-12 md:py-16 min-h-[70vh]">
+          <div className="hero-halo" aria-hidden="true" />
+
+          <DriftingLeaf
+            className="leaf-a"
+            style={{ top: "6%", left: "8%", width: 44, transform: "rotate(-18deg)", opacity: 0.7 }}
+          />
+          <DriftingLeaf
+            className="leaf-b"
+            style={{ top: "18%", right: "10%", width: 36, transform: "rotate(22deg)", opacity: 0.6 }}
+          />
+          <DriftingLeaf
+            className="leaf-c"
+            style={{ bottom: "14%", left: "14%", width: 30, transform: "rotate(-8deg)", opacity: 0.55 }}
+          />
+          <DriftingLeaf
+            className="leaf-a"
+            style={{ bottom: "24%", right: "16%", width: 26, transform: "rotate(12deg)", opacity: 0.5 }}
+          />
+
+          <Spore style={{ top: "28%", left: "22%", width: 5, height: 5, animationDelay: "0s" }} />
+          <Spore style={{ top: "40%", right: "24%", width: 4, height: 4, animationDelay: "1.8s" }} />
+          <Spore style={{ bottom: "30%", left: "30%", width: 6, height: 6, animationDelay: "3.2s" }} />
+          <Spore style={{ bottom: "18%", right: "30%", width: 4, height: 4, animationDelay: "4.6s" }} />
+
+          <div className="hero-rise relative text-[11px] tracking-[0.28em] uppercase text-stem font-mono mb-4">
+            Planche égarée · n° 4‑0‑4
+          </div>
+
+          <div
+            className="hero-rise relative mb-6"
+            style={{ animationDelay: "120ms" }}
+          >
+            <div className="flex items-center justify-center" style={{ width: 180, height: 210 }}>
+              <AnimatedPlant status="wilted" pot halo drops pollen />
+            </div>
+          </div>
+
+          <h1
+            className="hero-rise relative font-display italic font-semibold text-bark text-center leading-none"
+            style={{ animationDelay: "220ms" }}
+            aria-label="Erreur 404"
+          >
+            <span className="block text-7xl md:text-9xl tabular-nums">
+              <span className="notfound-digit notfound-digit-a">4</span>
+              <span className="notfound-digit notfound-digit-b mx-2 md:mx-3">0</span>
+              <span className="notfound-digit notfound-digit-c">4</span>
+            </span>
+          </h1>
+
+          <div
+            className="hero-rise relative flex items-center gap-3 mt-4 mb-3"
+            style={{ animationDelay: "320ms" }}
+          >
+            <span className="h-px w-10 bg-sage/30" />
+            <span className="text-[11px] font-mono tracking-[0.22em] uppercase text-stem">
+              sentier perdu
+            </span>
+            <span className="h-px w-10 bg-sage/30" />
+          </div>
+
+          <p
+            className="hero-rise relative font-display italic text-2xl md:text-3xl text-bark text-center max-w-lg mb-3 leading-tight"
+            style={{ animationDelay: "400ms" }}
+          >
+            Ce sentier s'arrête là.
+          </p>
+
+          <p
+            className="hero-rise relative text-sm md:text-base text-stem text-center max-w-md mb-8 leading-relaxed"
+            style={{ animationDelay: "480ms" }}
+          >
+            La page que tu cherchais ne pousse pas ici — ou plus.
+            <br className="hidden md:block" /> Le jardinier a laissé la parcelle en friche.
+          </p>
+
+          <div
+            className="hero-rise relative flex flex-wrap items-center justify-center gap-3"
+            style={{ animationDelay: "560ms" }}
+          >
+            <Link to="/" className="pill">
+              Retour à la serre
+            </Link>
+            <Link to="/skill-tree" className="pill pill-ghost">
+              Voir la carte
+            </Link>
+          </div>
+
+          <div
+            className="hero-rise relative mt-12 text-[10px] font-mono tracking-[0.22em] uppercase text-twig"
+            style={{ animationDelay: "640ms" }}
+          >
+            Jardin de CollegIA · carnet des sentiers
+          </div>
+        </section>
+      </Page>
+
+      <style>{`
+        @keyframes notfound-bob {
+          0%, 100% { transform: translateY(0) rotate(0) }
+          50%      { transform: translateY(-7px) rotate(-1.5deg) }
+        }
+        @keyframes notfound-bob-alt {
+          0%, 100% { transform: translateY(-3px) rotate(1deg) }
+          50%      { transform: translateY(4px) rotate(-1deg) }
+        }
+        .notfound-digit {
+          display: inline-block;
+          will-change: transform;
+        }
+        .notfound-digit-a { animation: notfound-bob 3.8s ease-in-out 0s infinite; color: #3F6F4A }
+        .notfound-digit-b { animation: notfound-bob-alt 3.2s ease-in-out 0.25s infinite; color: #B7615C }
+        .notfound-digit-c { animation: notfound-bob 3.8s ease-in-out 0.5s infinite; color: #3F6F4A }
+        @media (prefers-reduced-motion: reduce) {
+          .notfound-digit { animation: none }
+        }
+      `}</style>
+    </AppShell>
+  )
+}

--- a/frontend/src/components/screens/SkillTreeScreen.jsx
+++ b/frontend/src/components/screens/SkillTreeScreen.jsx
@@ -17,7 +17,7 @@ import { useAuthStore } from "../../stores/authStore"
 import { useSkillTree } from "../../hooks/useSkillTree"
 import AppShell from "../layout/AppShell"
 import SkillNode from "../ui/SkillNode"
-import Plant from "../ui/Plant"
+import AnimatedPlant, { PlantKeyframes } from "../ui/PlantAnimated"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Input from "../ui/Input"
@@ -385,6 +385,7 @@ function SkillTreeInner({ skills, skillTreeData, isLoading }) {
 
   return (
     <AppShell surface="plain" className="overflow-hidden">
+      <PlantKeyframes />
       <header className="border-b border-sage/10 bg-paper">
         <div className="flex items-center gap-2 px-3 sm:px-4 md:px-6 py-3 min-w-0">
           <a
@@ -589,8 +590,18 @@ function StatusLegend() {
     >
       {items.map(({ status, mastery, label }) => (
         <div key={label} className="flex items-center gap-2 text-[11px] text-bark">
-          <span className="w-6 h-6 flex items-center justify-center shrink-0">
-            <Plant status={status} mastery={mastery} size={22} />
+          <span
+            className="flex items-center justify-center shrink-0"
+            style={{ width: 24, height: 28 }}
+          >
+            <AnimatedPlant
+              status={status}
+              mastery={mastery}
+              pot={false}
+              halo={false}
+              drops={false}
+              pollen={false}
+            />
           </span>
           {label}
         </div>
@@ -695,7 +706,19 @@ function DetailPanel({ skill, state, skillsById, masteryById, onClose, onPractic
           background: "linear-gradient(180deg, var(--color-mist) 0%, var(--color-sage-pale) 100%)",
         }}
       >
-        <Plant status={sentierStatus} mastery={state?.mastery_level ?? 0} size={64} />
+        <span
+          className="flex items-center justify-center"
+          style={{ width: 72, height: 84 }}
+        >
+          <AnimatedPlant
+            status={sentierStatus}
+            mastery={state?.mastery_level ?? 0}
+            pot={false}
+            halo={false}
+            drops
+            pollen
+          />
+        </span>
         <span className="inline-flex items-center gap-2 bg-bone px-3 py-1 rounded-full text-xs font-semibold text-bark border border-sage/15">
           <span
             className="w-2.5 h-2.5 rounded-full"

--- a/frontend/src/components/screens/WelcomeScreen.jsx
+++ b/frontend/src/components/screens/WelcomeScreen.jsx
@@ -15,7 +15,7 @@ import XPBar from "../xp/XPBar"
 import StreakFlame from "../streak/StreakFlame"
 import DailyGoalProgress from "../streak/DailyGoalProgress"
 import BadgeGallery from "../badges/BadgeGallery"
-import Plant from "../ui/Plant"
+import AnimatedPlant, { PlantKeyframes } from "../ui/PlantAnimated"
 
 const MASTERY_BUCKETS = [
   {
@@ -91,8 +91,18 @@ function MasterySummary({ summary, onFocus }) {
                   : "opacity-55 cursor-default"
               }`}
             >
-              <span className="h-12 flex items-end justify-center">
-                <Plant status={plant.status} mastery={plant.mastery} size={36} />
+              <span
+                className="flex items-center justify-center"
+                style={{ width: 44, height: 52 }}
+              >
+                <AnimatedPlant
+                  status={plant.status}
+                  mastery={plant.mastery}
+                  pot={false}
+                  halo={false}
+                  drops={false}
+                  pollen={false}
+                />
               </span>
               <span className={`font-mono text-2xl font-semibold mt-1 ${tone}`}>
                 {value}
@@ -137,6 +147,7 @@ export default function WelcomeScreen() {
         />
       }
     >
+      <PlantKeyframes />
       <Page maxWidth="xl">
         <header className="mb-8">
           <Heading level={1} className="text-balance">

--- a/frontend/src/components/ui/PlantAnimated.jsx
+++ b/frontend/src/components/ui/PlantAnimated.jsx
@@ -1,0 +1,338 @@
+// Animated JARDIN plants — debug-only experiments behind /debug/plants.
+// Mirrors the aesthetic of Loader.jsx (halo pulse, stem sway, leaf
+// wiggle, water drops). Production SkillNode keeps using Plant.jsx.
+
+const VB = "0 0 120 140"
+const STEM = "#3F6F4A"
+const LEAF = "#C7E0B5"
+
+function Pot() {
+  return (
+    <g>
+      <path
+        d="M40 118 L 43 136 Q 43 138 46 138 L 74 138 Q 77 138 77 136 L 80 118 Z"
+        fill="#D8B48A"
+        stroke="#8A6A4A"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <ellipse cx="60" cy="118" rx="20" ry="3.5" fill="#B88D5F" stroke="#8A6A4A" strokeWidth="1.4" />
+      <ellipse cx="60" cy="118" rx="17" ry="2.3" fill="#4C3621" />
+    </g>
+  )
+}
+
+function Halo({ tint = "sage" }) {
+  const id = `jp-halo-${tint}`
+  const color = tint === "honey" ? "#F6DE9F" : tint === "rose" ? "#F0BEBA" : "#BEDDA8"
+  return (
+    <>
+      <defs>
+        <radialGradient id={id} cx="50%" cy="55%" r="55%">
+          <stop offset="0%" stopColor={color} stopOpacity="0.65" />
+          <stop offset="100%" stopColor={color} stopOpacity="0" />
+        </radialGradient>
+      </defs>
+      <circle cx="60" cy="82" r="56" fill={`url(#${id})`} className={`jp-halo jp-halo-${tint}`} />
+    </>
+  )
+}
+
+export function AnimatedSeed({ pot = true, halo = true }) {
+  return (
+    <svg viewBox={VB} width="100%" height="100%" aria-hidden="true" className="jp overflow-visible">
+      {halo && <Halo tint="sage" />}
+      <g className="jp-seed-breath" style={{ transformOrigin: "60px 106px", transformBox: "fill-box" }}>
+        <ellipse cx="60" cy="106" rx="13" ry="16" fill="#C9A373" stroke="#5A3E1F" strokeWidth="1.8" />
+        <path d="M53 102 Q 60 90 67 102" fill="none" stroke="#5A3E1F" strokeWidth="1.2" strokeLinecap="round" />
+        <path d="M53 102 Q 60 90 67 102" fill="none" stroke="#FBE9B6" strokeWidth="1.1" strokeLinecap="round" className="jp-seed-glow" />
+        <path d="M60 92 Q 60 86 60 82" fill="none" stroke="#6FA274" strokeWidth="1.4" strokeLinecap="round" className="jp-seed-tip" />
+      </g>
+      <circle cx="40" cy="116" r="1.4" fill="#A88558" className="jp-dust jp-dust-1" />
+      <circle cx="82" cy="116" r="1.2" fill="#A88558" className="jp-dust jp-dust-2" />
+      <circle cx="56" cy="120" r="1.2" fill="#FBE9B6" className="jp-dust jp-dust-3" />
+      {pot && <Pot />}
+    </svg>
+  )
+}
+
+export function AnimatedSprout({ pot = true, halo = true }) {
+  return (
+    <svg viewBox={VB} width="100%" height="100%" aria-hidden="true" className="jp overflow-visible">
+      {halo && <Halo tint="sage" />}
+      <g className="jp-sprout-sway" style={{ transformOrigin: "60px 118px", transformBox: "fill-box" }}>
+        <path d="M60 118 Q 60 96 60 80" fill="none" stroke={STEM} strokeWidth="2.2" strokeLinecap="round" />
+        <g className="jp-sprout-left" style={{ transformOrigin: "60px 80px", transformBox: "fill-box" }}>
+          <ellipse cx="46" cy="74" rx="11" ry="6" fill={LEAF} stroke={STEM} strokeWidth="1.3" transform="rotate(-20 46 74)" />
+          <path d="M58 78 Q 50 76 37 72" stroke={STEM} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.65" />
+        </g>
+        <g className="jp-sprout-right" style={{ transformOrigin: "60px 80px", transformBox: "fill-box" }}>
+          <ellipse cx="74" cy="74" rx="11" ry="6" fill={LEAF} stroke={STEM} strokeWidth="1.3" transform="rotate(20 74 74)" />
+          <path d="M62 78 Q 70 76 83 72" stroke={STEM} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.65" />
+        </g>
+        <ellipse cx="60" cy="76" rx="1.6" ry="2.2" fill="#4F8BAC" opacity="0.85" className="jp-dew" />
+      </g>
+      {pot && <Pot />}
+    </svg>
+  )
+}
+
+export function AnimatedBud({ pot = true, halo = true, drops = true }) {
+  return (
+    <svg viewBox={VB} width="100%" height="100%" aria-hidden="true" className="jp overflow-visible">
+      {halo && <Halo tint="sage" />}
+      {drops && (
+        <g className="jp-drops">
+          <path d="M60 6 Q 63 13 60 18 Q 57 13 60 6 Z" fill="#4F8BAC" opacity="0.75" className="jp-drop jp-drop-1" />
+          <path d="M42 10 Q 45 17 42 22 Q 39 17 42 10 Z" fill="#4F8BAC" opacity="0.6" className="jp-drop jp-drop-2" />
+          <path d="M78 14 Q 81 21 78 26 Q 75 21 78 14 Z" fill="#4F8BAC" opacity="0.6" className="jp-drop jp-drop-3" />
+        </g>
+      )}
+      <g className="jp-bud-sway" style={{ transformOrigin: "60px 118px", transformBox: "fill-box" }}>
+        <path d="M60 118 Q 58 96 60 72 Q 62 58 60 44" fill="none" stroke={STEM} strokeWidth="2.2" strokeLinecap="round" />
+        <g className="jp-leaf-left" style={{ transformOrigin: "60px 82px", transformBox: "fill-box" }}>
+          <ellipse cx="44" cy="76" rx="13" ry="6" fill={LEAF} stroke={STEM} strokeWidth="1.3" transform="rotate(-24 44 76)" />
+          <path d="M58 78 Q 50 76 33 72" stroke={STEM} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.6" />
+        </g>
+        <g className="jp-leaf-right" style={{ transformOrigin: "60px 82px", transformBox: "fill-box" }}>
+          <ellipse cx="76" cy="76" rx="13" ry="6" fill={LEAF} stroke={STEM} strokeWidth="1.3" transform="rotate(24 76 76)" />
+          <path d="M62 78 Q 70 76 87 72" stroke={STEM} strokeWidth="0.9" fill="none" strokeLinecap="round" opacity="0.6" />
+        </g>
+        <g className="jp-bud-pulse" style={{ transformOrigin: "60px 36px", transformBox: "fill-box" }}>
+          <path d="M60 46 Q 52 46 52 38 Q 52 28 60 24 Q 68 28 68 38 Q 68 46 60 46 Z" fill="#F5D3D0" stroke="#5A3E1F" strokeWidth="1.3" />
+          <path d="M60 46 L 60 24" stroke="#CF7A74" strokeWidth="0.9" fill="none" />
+        </g>
+      </g>
+      {pot && <Pot />}
+    </svg>
+  )
+}
+
+export function AnimatedFlower({ pot = true, halo = true, pollen = true }) {
+  const BACK = 14
+  const FRONT = 10
+  const back = Array.from({ length: BACK }, (_, i) => (360 / BACK) * i)
+  const front = Array.from({ length: FRONT }, (_, i) => (360 / FRONT) * i + 18)
+  const stamens = [0, 60, 120, 180, 240, 300]
+  const pollenDots = [0, 1, 2, 3, 4, 5, 6, 7]
+  return (
+    <svg viewBox={VB} width="100%" height="100%" aria-hidden="true" className="jp overflow-visible">
+      {halo && <Halo tint="honey" />}
+      {pollen && (
+        <g className="jp-pollen">
+          {pollenDots.map((i) => (
+            <circle
+              key={i}
+              cx={34 + i * 7.2}
+              cy="42"
+              r={i % 2 === 0 ? 1.8 : 1.3}
+              fill={i % 3 === 0 ? "#F5D3D0" : "#E8C66A"}
+              opacity="0.85"
+              className={`jp-pollen-dot jp-pollen-${i % 5}`}
+            />
+          ))}
+        </g>
+      )}
+      <g className="jp-flower-sway" style={{ transformOrigin: "60px 118px", transformBox: "fill-box" }}>
+        <path d="M60 118 Q 58 96 60 72 Q 62 56 60 40" fill="none" stroke={STEM} strokeWidth="2.2" strokeLinecap="round" />
+        <path d="M60 90 Q 70 86 80 78" fill="none" stroke={STEM} strokeWidth="1.4" strokeLinecap="round" />
+        <g className="jp-mini-bud-right" style={{ transformOrigin: "80px 78px", transformBox: "fill-box" }}>
+          <circle cx="80" cy="76" r="3.6" fill="#F5D3D0" stroke="#CF7A74" strokeWidth="1" />
+          <circle cx="80" cy="76" r="1.3" fill="#E8C66A" />
+        </g>
+        <path d="M60 100 Q 50 98 42 94" fill="none" stroke={STEM} strokeWidth="1.3" strokeLinecap="round" />
+        <g className="jp-mini-bud-left" style={{ transformOrigin: "42px 93px", transformBox: "fill-box" }}>
+          <circle cx="42" cy="93" r="2.8" fill="#F5D3D0" stroke="#CF7A74" strokeWidth="1" />
+          <circle cx="42" cy="93" r="1" fill="#E8C66A" />
+        </g>
+        <g className="jp-leaf-left" style={{ transformOrigin: "60px 82px", transformBox: "fill-box" }}>
+          <ellipse cx="44" cy="76" rx="13" ry="6" fill={LEAF} stroke={STEM} strokeWidth="1.3" transform="rotate(-24 44 76)" />
+        </g>
+        <g className="jp-leaf-right" style={{ transformOrigin: "60px 82px", transformBox: "fill-box" }}>
+          <ellipse cx="76" cy="76" rx="13" ry="6" fill={LEAF} stroke={STEM} strokeWidth="1.3" transform="rotate(24 76 76)" />
+        </g>
+        <path d="M54 44 Q 52 40 55 36 Q 58 38 57 44 Z" fill="#A9CD8E" stroke={STEM} strokeWidth="0.9" />
+        <path d="M66 44 Q 68 40 65 36 Q 62 38 63 44 Z" fill="#A9CD8E" stroke={STEM} strokeWidth="0.9" />
+        <g className="jp-bloom" style={{ transformOrigin: "60px 38px", transformBox: "fill-box" }}>
+          {back.map((r, i) => (
+            <g key={`b${i}`} transform={`rotate(${r} 60 38)`}>
+              <ellipse
+                cx="60"
+                cy="24"
+                rx="4.5"
+                ry="13"
+                fill="#F5D3D0"
+                stroke="#CF7A74"
+                strokeWidth="1.1"
+                className={`jp-petal jp-petal-${i % 8}`}
+                style={{ transformOrigin: "50% 100%", transformBox: "fill-box" }}
+              />
+            </g>
+          ))}
+          {front.map((r, i) => (
+            <g key={`f${i}`} transform={`rotate(${r} 60 38)`}>
+              <ellipse
+                cx="60"
+                cy="28"
+                rx="3.5"
+                ry="9"
+                fill="#FBE5E2"
+                stroke="#CF7A74"
+                strokeWidth="0.9"
+                className={`jp-petal jp-petal-front jp-petal-${(i + 3) % 8}`}
+                style={{ transformOrigin: "50% 100%", transformBox: "fill-box" }}
+              />
+            </g>
+          ))}
+          <circle cx="60" cy="38" r="6.5" fill="#F4D98A" stroke="#C99845" strokeWidth="1.2" />
+          {stamens.map((a, i) => (
+            <circle
+              key={i}
+              cx="60"
+              cy="32.5"
+              r="1.4"
+              fill="#B7842F"
+              transform={`rotate(${a} 60 38)`}
+              className={`jp-stamen jp-stamen-${i}`}
+            />
+          ))}
+          <circle cx="60" cy="38" r="2.6" fill="#8E5F1E" />
+        </g>
+      </g>
+      {pollen && (
+        <ellipse cx="92" cy="52" rx="3" ry="5" fill="#FBE5E2" opacity="0.75" className="jp-drift-petal" />
+      )}
+      {pot && <Pot />}
+    </svg>
+  )
+}
+
+export function AnimatedWilted({ pot = true, halo = true }) {
+  return (
+    <svg viewBox={VB} width="100%" height="100%" aria-hidden="true" className="jp overflow-visible">
+      {halo && <Halo tint="rose" />}
+      <path d="M60 10 Q 63 18 60 24 Q 57 18 60 10 Z" fill="#4F8BAC" opacity="0.75" className="jp-revive-drop" />
+      <g className="jp-wilt-droop" style={{ transformOrigin: "60px 118px", transformBox: "fill-box" }}>
+        <path d="M60 118 Q 56 96 58 76 Q 62 58 72 46" fill="none" stroke="#8A9A8A" strokeWidth="2.2" strokeLinecap="round" />
+        <g className="jp-wilt-leaf-left" style={{ transformOrigin: "60px 84px", transformBox: "fill-box" }}>
+          <ellipse cx="44" cy="86" rx="12" ry="6" fill="#D8DEC7" stroke="#8A9A8A" strokeWidth="1.3" transform="rotate(-34 44 86)" />
+        </g>
+        <g className="jp-wilt-leaf-right" style={{ transformOrigin: "60px 80px", transformBox: "fill-box" }}>
+          <ellipse cx="74" cy="82" rx="12" ry="6" fill="#D8DEC7" stroke="#8A9A8A" strokeWidth="1.3" transform="rotate(14 74 82)" />
+        </g>
+        <g transform="translate(12 -4)" className="jp-wilt-head">
+          <ellipse cx="70" cy="44" rx="4.5" ry="8" fill="#E6CFC7" stroke="#7D5A54" strokeWidth="1.1" />
+          <ellipse cx="70" cy="44" rx="4.5" ry="8" fill="#E6CFC7" stroke="#7D5A54" strokeWidth="1.1" transform="rotate(55 70 44)" />
+          <ellipse cx="70" cy="44" rx="4.5" ry="8" fill="#E0C3BA" stroke="#7D5A54" strokeWidth="1.1" transform="rotate(180 70 44)" opacity="0.75" />
+          <ellipse cx="70" cy="44" rx="4.5" ry="8" fill="#E6CFC7" stroke="#7D5A54" strokeWidth="1.1" transform="rotate(300 70 44)" />
+          <circle cx="70" cy="44" r="3.2" fill="#C9A860" stroke="#7D5A54" strokeWidth="1.1" />
+        </g>
+      </g>
+      <ellipse cx="86" cy="66" rx="4" ry="6" fill="#E6CFC7" opacity="0.8" className="jp-falling-petal" />
+      {pot && <Pot />}
+    </svg>
+  )
+}
+
+export default function AnimatedPlant({ status, mastery = 0, ...rest }) {
+  if (status === "locked" || status === "unlocked") return <AnimatedSeed {...rest} />
+  if (status === "wilted") return <AnimatedWilted {...rest} />
+  if (status === "done") return <AnimatedFlower {...rest} />
+  if (mastery < 0.35) return <AnimatedSprout {...rest} />
+  return <AnimatedBud {...rest} />
+}
+
+export function PlantKeyframes() {
+  return (
+    <style>{`
+@keyframes jp-seed-breath { 0%,100% { transform: scale(1) } 50% { transform: scale(1.05) } }
+@keyframes jp-seed-glow   { 0%,100% { opacity: 0.12 } 50% { opacity: 0.95 } }
+@keyframes jp-seed-tip    { 0%,72%,100% { opacity: 0 } 82%,95% { opacity: 0.7 } }
+@keyframes jp-dust        { 0% { transform: translateY(0); opacity: 0 } 15% { opacity: 0.9 } 90% { opacity: 0 } 100% { transform: translateY(-44px); opacity: 0 } }
+@keyframes jp-sway        { 0%,100% { transform: rotate(-2.4deg) } 50% { transform: rotate(2.4deg) } }
+@keyframes jp-sway-soft   { 0%,100% { transform: rotate(-1.5deg) } 50% { transform: rotate(1.5deg) } }
+@keyframes jp-leaf-left   { 0%,100% { transform: rotate(0) } 50% { transform: rotate(-6deg) } }
+@keyframes jp-leaf-right  { 0%,100% { transform: rotate(0) } 50% { transform: rotate(6deg) } }
+@keyframes jp-halo-sage   { 0%,100% { opacity: 0.55; transform: scale(1) } 50% { opacity: 0.95; transform: scale(1.07) } }
+@keyframes jp-halo-honey  { 0%,100% { opacity: 0.55; transform: scale(1) } 50% { opacity: 1; transform: scale(1.1) } }
+@keyframes jp-halo-rose   { 0%,100% { opacity: 0.3; transform: scale(1) } 50% { opacity: 0.55; transform: scale(1.04) } }
+@keyframes jp-drop        { 0% { transform: translateY(-10px); opacity: 0 } 15% { opacity: 0.9 } 70% { opacity: 0.9 } 90%,100% { transform: translateY(50px); opacity: 0 } }
+@keyframes jp-bud-pulse   { 0%,100% { transform: scale(1) } 50% { transform: scale(1.14) } }
+@keyframes jp-dew         { 0%,60% { transform: translateY(0); opacity: 0 } 72% { opacity: 0.9 } 100% { transform: translateY(14px); opacity: 0 } }
+@keyframes jp-pollen      { 0% { transform: translateY(0); opacity: 0 } 15% { opacity: 0.9 } 100% { transform: translateY(-46px); opacity: 0 } }
+@keyframes jp-petal       { 0%,100% { transform: scale(1) } 50% { transform: scale(1.09) } }
+@keyframes jp-petal-front { 0%,100% { transform: scale(1) } 50% { transform: scale(0.92) } }
+@keyframes jp-bloom       { 0%,100% { transform: scale(1) rotate(0deg) } 50% { transform: scale(1.025) rotate(0.6deg) } }
+@keyframes jp-stamen      { 0%,100% { transform: translateY(0) } 50% { transform: translateY(-1.2px) } }
+@keyframes jp-mini-bud    { 0%,100% { transform: scale(1) } 50% { transform: scale(1.12) } }
+@keyframes jp-drift-petal { 0% { transform: translate(0,0) rotate(0); opacity: 0 } 10% { opacity: 0.8 } 100% { transform: translate(16px,52px) rotate(220deg); opacity: 0 } }
+@keyframes jp-wilt-droop  { 0%,100% { transform: rotate(-1deg) } 50% { transform: rotate(3deg) translateY(1px) } }
+@keyframes jp-wilt-leaf   { 0%,100% { transform: rotate(0) } 50% { transform: rotate(3deg) } }
+@keyframes jp-wilt-head   { 0%,100% { transform: translate(12px,-4px) } 50% { transform: translate(12px,-2px) } }
+@keyframes jp-revive-drop { 0% { transform: translateY(-4px); opacity: 0 } 10% { opacity: 0.9 } 70% { transform: translateY(30px); opacity: 0.4 } 80%,100% { transform: translateY(30px); opacity: 0 } }
+@keyframes jp-falling-petal { 0% { transform: translate(0,0) rotate(0); opacity: 0 } 10% { opacity: 0.85 } 100% { transform: translate(6px,28px) rotate(160deg); opacity: 0 } }
+
+.jp-halo                { transform-origin: 60px 82px; transform-box: fill-box }
+.jp-halo-sage           { animation: jp-halo-sage 3.4s ease-in-out infinite }
+.jp-halo-honey          { animation: jp-halo-honey 3s ease-in-out infinite }
+.jp-halo-rose           { animation: jp-halo-rose 4.2s ease-in-out infinite }
+
+.jp-seed-breath         { animation: jp-seed-breath 3.2s ease-in-out infinite }
+.jp-seed-glow           { animation: jp-seed-glow 2.4s ease-in-out infinite }
+.jp-seed-tip            { animation: jp-seed-tip 6s ease-in-out infinite }
+.jp-dust-1              { animation: jp-dust 5s linear 0s infinite }
+.jp-dust-2              { animation: jp-dust 5s linear 1.7s infinite }
+.jp-dust-3              { animation: jp-dust 5s linear 3.3s infinite }
+
+.jp-sprout-sway         { animation: jp-sway-soft 3s ease-in-out infinite }
+.jp-sprout-left         { animation: jp-leaf-left 2.6s ease-in-out infinite }
+.jp-sprout-right        { animation: jp-leaf-right 2.6s ease-in-out infinite }
+.jp-dew                 { animation: jp-dew 4.2s ease-in-out infinite; transform-origin: 60px 76px; transform-box: fill-box }
+
+.jp-bud-sway            { animation: jp-sway 3.4s ease-in-out infinite }
+.jp-leaf-left           { animation: jp-leaf-left 2.8s ease-in-out infinite }
+.jp-leaf-right          { animation: jp-leaf-right 2.8s ease-in-out infinite }
+.jp-bud-pulse           { animation: jp-bud-pulse 2.2s ease-in-out infinite }
+.jp-drop-1              { animation: jp-drop 2.3s ease-in 0s infinite }
+.jp-drop-2              { animation: jp-drop 2.3s ease-in 0.55s infinite }
+.jp-drop-3              { animation: jp-drop 2.3s ease-in 1.1s infinite }
+
+.jp-flower-sway         { animation: jp-sway-soft 3.6s ease-in-out infinite }
+.jp-bloom               { animation: jp-bloom 4.4s ease-in-out infinite }
+.jp-petal-0             { animation: jp-petal 2.8s ease-in-out 0s infinite }
+.jp-petal-1             { animation: jp-petal 3.1s ease-in-out 0.15s infinite }
+.jp-petal-2             { animation: jp-petal 2.6s ease-in-out 0.3s infinite }
+.jp-petal-3             { animation: jp-petal 3.3s ease-in-out 0.45s infinite }
+.jp-petal-4             { animation: jp-petal 2.9s ease-in-out 0.6s infinite }
+.jp-petal-5             { animation: jp-petal 2.7s ease-in-out 0.75s infinite }
+.jp-petal-6             { animation: jp-petal 3.2s ease-in-out 0.9s infinite }
+.jp-petal-7             { animation: jp-petal 2.8s ease-in-out 1.05s infinite }
+.jp-petal-front         { animation-name: jp-petal-front }
+.jp-stamen-0            { animation: jp-stamen 2.2s ease-in-out 0s infinite }
+.jp-stamen-1            { animation: jp-stamen 2.2s ease-in-out 0.3s infinite }
+.jp-stamen-2            { animation: jp-stamen 2.2s ease-in-out 0.6s infinite }
+.jp-stamen-3            { animation: jp-stamen 2.2s ease-in-out 0.9s infinite }
+.jp-stamen-4            { animation: jp-stamen 2.2s ease-in-out 1.2s infinite }
+.jp-stamen-5            { animation: jp-stamen 2.2s ease-in-out 1.5s infinite }
+.jp-mini-bud-left       { animation: jp-mini-bud 3.4s ease-in-out 0.5s infinite }
+.jp-mini-bud-right      { animation: jp-mini-bud 3.4s ease-in-out 0s infinite }
+.jp-drift-petal         { animation: jp-drift-petal 6.5s ease-in 1.2s infinite }
+.jp-pollen-0            { animation: jp-pollen 4.6s ease-out 0s infinite }
+.jp-pollen-1            { animation: jp-pollen 4.6s ease-out 0.55s infinite }
+.jp-pollen-2            { animation: jp-pollen 4.6s ease-out 1.1s infinite }
+.jp-pollen-3            { animation: jp-pollen 4.6s ease-out 1.65s infinite }
+.jp-pollen-4            { animation: jp-pollen 4.6s ease-out 2.2s infinite }
+
+.jp-wilt-droop          { animation: jp-wilt-droop 5.6s ease-in-out infinite }
+.jp-wilt-leaf-left      { animation: jp-wilt-leaf 5.6s ease-in-out infinite }
+.jp-wilt-leaf-right     { animation: jp-wilt-leaf 5.6s ease-in-out infinite reverse }
+.jp-wilt-head           { animation: jp-wilt-head 5.6s ease-in-out infinite }
+.jp-revive-drop         { animation: jp-revive-drop 4.2s ease-in-out infinite }
+.jp-falling-petal       { animation: jp-falling-petal 4.6s ease-in 0.4s infinite }
+
+.jp-paused *            { animation-play-state: paused !important }
+
+@media (prefers-reduced-motion: reduce) { .jp *, .jp-paused * { animation: none !important } }
+`}</style>
+  )
+}

--- a/frontend/src/components/ui/SkillNode.jsx
+++ b/frontend/src/components/ui/SkillNode.jsx
@@ -2,7 +2,7 @@ import { useContext } from "react"
 import { Handle, Position } from "@xyflow/react"
 import { SkillTreeHoverContext } from "../../lib/skillTreeHoverContext"
 import { SENTIER_LABEL } from "../../lib/skillStatus"
-import Plant from "./Plant"
+import AnimatedPlant from "./PlantAnimated"
 
 const STATE_LABEL = SENTIER_LABEL
 
@@ -75,7 +75,9 @@ export default function SkillNode({ id, data }) {
           ? "is-today"
           : ""
 
-  const plantSize = isToday ? 58 : 50
+  const plantWidth = isToday ? 76 : 66
+  const plantHeight = Math.round((plantWidth * 140) / 120)
+  const flourish = isToday || isHoverTarget
   const dim = sentierStatus === "locked" && totalAttempts === 0
 
   return (
@@ -93,7 +95,19 @@ export default function SkillNode({ id, data }) {
           className={`disc-body ${bodyModifier}`}
           style={{ width: "100%", height: "100%" }}
         >
-          <Plant status={sentierStatus} mastery={masteryLevel} size={plantSize} />
+          <div
+            className="flex items-center justify-center"
+            style={{ width: plantWidth, height: plantHeight }}
+          >
+            <AnimatedPlant
+              status={sentierStatus}
+              mastery={masteryLevel}
+              pot={false}
+              halo={false}
+              drops={flourish}
+              pollen={flourish}
+            />
+          </div>
           {isLocked && (
             <div
               className="absolute top-1 right-1 w-5 h-5 rounded-full bg-paper border border-sage/25 flex items-center justify-center text-stem"


### PR DESCRIPTION
## Summary

- **Animated plant system** — new `PlantAnimated.jsx` with five state-tailored motion palettes (seed breath · sprout wag · bud pulse · flower bloom · wilted droop-and-revive). The flower is now a two-layered 24-petal bloom with stamens, side buds, sepals, pollen field, and a drifting petal.
- **`/debug/plants`** — dev-only observatory to iterate on plant motion. Auto-cycling hero, specimen gallery, static-vs-animated comparison.
- **Wired into production surfaces** — skill tree disc medallions, welcome-screen mastery cards, skill-tree legend, skill-tree detail panel. Expensive flourishes (raindrops, pollen, drifting petal) are gated to the *today* node + *hovered* node to keep perf reasonable on 100+ nodes.
- **Closes #171** — SPA catch-all route rendering a botanical 404 screen: wilted plant centerpiece, individually-bobbing "404" digits in Fraunces italic, drifting leaves, spore particles, warm copy ("Ce sentier s'arrête là."), and a CollegIA footer.

A subtle bug in the old static flower (CSS `transform: scale()` overriding the SVG `transform="rotate(X)"` attribute and collapsing every petal to angle 0 mid-animation) is fixed by wrapping each petal in its own `<g transform="rotate(...)">` and scaling the child ellipse.

## Test plan

- [ ] `/debug/plants` (dev, requires auth) — auto-cycle runs through all five states, toggles (halo / pot / animé) work, "avant · après" panel switches states
- [ ] `/skill-tree` — plants in disc medallions breathe/sway; today-node and hovered node show drops/pollen; legend (top-left) and detail panel (on node click) use the animated plants
- [ ] `/` (Welcome, logged in) — five mastery-bucket cards animate subtly
- [ ] `/any-bogus-path` — botanical 404 renders with staggered entrance; "Retour à la serre" routes to `/`, "Voir la carte" routes to `/skill-tree`
- [ ] `prefers-reduced-motion: reduce` in DevTools pauses all plant + digit animations
- [ ] No visible regression on Loader (`Loader.jsx` untouched) or static `Plant.jsx` (still used in a few non-disc contexts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)