### PR TITLE
feat(#156,#182): Atelier dashboard + template playground

### DIFF
--- a/backend/apps/exercises/atelier_views.py
+++ b/backend/apps/exercises/atelier_views.py
@@ -1,0 +1,190 @@
+"""Dev-only endpoints powering the Atelier (skill-health dashboard + playground)."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from pathlib import Path
+
+from django.conf import settings
+from django.http import Http404
+from django.shortcuts import get_object_or_404
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from apps.skills.models import Skill
+from src.services.exercise_gen import instantiate
+
+from .models import ExerciseTemplate
+
+AUDIT_PATH = Path(settings.BASE_DIR).parent / "artifacts/audit/combined.json"
+
+
+def _require_dev(request) -> None:
+    if settings.ENVIRONMENT != "dev" and not request.user.is_staff:
+        raise Http404
+
+
+def _load_audit() -> dict | None:
+    if not AUDIT_PATH.exists():
+        return None
+    try:
+        return json.loads(AUDIT_PATH.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _live_skills_payload() -> dict:
+    """Fallback payload built from DB when audit artifacts are absent."""
+    skills = {s.id: s for s in Skill.objects.all()}
+    buckets: dict[str, dict] = {}
+    for sid, skill in skills.items():
+        buckets[sid] = {
+            "id": sid,
+            "label": skill.label,
+            "grade": skill.grade,
+            "template_count": 0,
+            "total_variants": 0,
+            "difficulty_tiers": [],
+            "input_types": [],
+            "avg_score": None,
+            "status": "no_coverage",
+            "templates": [],
+        }
+    templates = ExerciseTemplate.objects.prefetch_related("skills").all()
+    per_skill_tiers: dict[str, set[int]] = defaultdict(set)
+    per_skill_inputs: dict[str, set[str]] = defaultdict(set)
+    for tpl in templates:
+        for skill in tpl.skills.all():
+            bucket = buckets.get(skill.id)
+            if bucket is None:
+                continue
+            bucket["template_count"] += 1
+            per_skill_tiers[skill.id].add(tpl.difficulty)
+            per_skill_inputs[skill.id].add(tpl.input_type)
+            bucket["templates"].append(
+                {
+                    "id": tpl.id,
+                    "difficulty": tpl.difficulty,
+                    "input_type": tpl.input_type,
+                    "template_type": tpl.template.get("type", ""),
+                    "variant_count": None,
+                    "score": None,
+                    "score_reasons": [],
+                    "sample_prompts": [],
+                }
+            )
+    for sid, bucket in buckets.items():
+        bucket["difficulty_tiers"] = sorted(per_skill_tiers[sid])
+        bucket["input_types"] = sorted(per_skill_inputs[sid])
+        if bucket["template_count"] == 0:
+            bucket["status"] = "no_coverage"
+        elif len(bucket["difficulty_tiers"]) == 1:
+            bucket["status"] = "single_tier"
+        else:
+            bucket["status"] = "ok"
+    return {
+        "meta": {"source": "live", "n_skills": len(buckets), "n_templates": templates.count()},
+        "skills": buckets,
+    }
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def audit(request):
+    """Skill-health snapshot for the Atelier dashboard (dev-only)."""
+    _require_dev(request)
+    data = _load_audit()
+    if data is None:
+        return Response(_live_skills_payload())
+    return Response(
+        {
+            "meta": {**data.get("meta", {}), "source": "audit_artifact"},
+            "skills": data["skills"],
+        }
+    )
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def skill_detail(request, skill_id: str):
+    """Per-skill detail: skill + every template + audit info (when available)."""
+    _require_dev(request)
+    skill = get_object_or_404(Skill, id=skill_id)
+    templates = (
+        ExerciseTemplate.objects.filter(skills=skill)
+        .prefetch_related("skills")
+        .order_by("difficulty", "id")
+    )
+    audit_data = _load_audit() or {}
+    audit_templates = audit_data.get("templates", {})
+    audit_skill = audit_data.get("skills", {}).get(skill_id, {})
+
+    out_templates = []
+    for tpl in templates:
+        audit_tpl = audit_templates.get(tpl.id, {})
+        out_templates.append(
+            {
+                "id": tpl.id,
+                "difficulty": tpl.difficulty,
+                "input_type": tpl.input_type,
+                "template_type": tpl.template.get("type", ""),
+                "operation": tpl.template.get("operation"),
+                "prompt_template": tpl.template.get("prompt_template", ""),
+                "params": tpl.template.get("params", {}),
+                "variant_count": audit_tpl.get("variant_count"),
+                "score": audit_tpl.get("score"),
+                "score_reasons": audit_tpl.get("score_reasons", []),
+                "flags": audit_tpl.get("flags", {}),
+                "sample_prompts": audit_tpl.get("sample_prompts", []),
+                "sample_answers": audit_tpl.get("sample_answers", []),
+            }
+        )
+
+    return Response(
+        {
+            "skill": {"id": skill.id, "label": skill.label, "grade": skill.grade},
+            "summary": {
+                "template_count": len(out_templates),
+                "total_variants": audit_skill.get("total_variants"),
+                "difficulty_tiers": audit_skill.get(
+                    "difficulty_tiers", sorted({t.difficulty for t in templates})
+                ),
+                "input_types": audit_skill.get(
+                    "input_types", sorted({t.input_type for t in templates})
+                ),
+                "avg_score": audit_skill.get("avg_score"),
+                "status": audit_skill.get("status"),
+            },
+            "templates": out_templates,
+        }
+    )
+
+
+@api_view(["GET"])
+@permission_classes([IsAuthenticated])
+def template_preview(request, template_id: str):
+    """Generate a concrete preview for a specific template (dev-only playground)."""
+    _require_dev(request)
+    tpl = get_object_or_404(ExerciseTemplate.objects.prefetch_related("skills"), id=template_id)
+    try:
+        generated = instantiate(tpl.template)
+    except Exception as exc:  # noqa: BLE001 — surface generator error verbatim
+        return Response(
+            {"template_id": tpl.id, "error": f"{type(exc).__name__}: {exc}"},
+            status=200,
+        )
+    first_skill = tpl.skills.first()
+    return Response(
+        {
+            "template_id": tpl.id,
+            "skill_id": first_skill.id if first_skill else "",
+            "difficulty": tpl.difficulty,
+            "input_type": tpl.input_type,
+            "type": tpl.template.get("type", ""),
+            "prompt": generated["prompt"],
+            "answer": generated["answer"],
+            "params": generated["params"],
+        }
+    )

--- a/backend/apps/exercises/urls.py
+++ b/backend/apps/exercises/urls.py
@@ -1,5 +1,6 @@
 from django.urls import path
 
+from .atelier_views import audit, skill_detail, template_preview
 from .diagnostic_views import next_question as diagnostic_next
 from .diagnostic_views import result as diagnostic_result
 from .diagnostic_views import start as diagnostic_start
@@ -15,6 +16,13 @@ urlpatterns = [
     path("exercises/generate/", generate, name="exercises-generate"),
     path("exercises/next/", next_exercise, name="exercises-next"),
     path("exercises/samples/", samples, name="exercises-samples"),
+    path("exercises/audit/", audit, name="exercises-audit"),
+    path("exercises/audit/skill/<str:skill_id>/", skill_detail, name="exercises-audit-skill"),
+    path(
+        "exercises/templates/<str:template_id>/preview/",
+        template_preview,
+        name="exercises-template-preview",
+    ),
     path("attempts/<uuid:attempt_id>/explain/", explain_attempt, name="attempts-explain"),
     path("diagnostic/start/", diagnostic_start, name="diagnostic-start"),
     path(

--- a/backend/tests/test_atelier_api.py
+++ b/backend/tests/test_atelier_api.py
@@ -1,0 +1,76 @@
+import pytest
+from django.test import override_settings
+
+
+@pytest.mark.django_db
+def test_audit_requires_auth(api):
+    res = api.get("/api/exercises/audit/")
+    assert res.status_code in (401, 403)
+
+
+@pytest.mark.django_db
+@override_settings(ENVIRONMENT="prod")
+def test_audit_hidden_in_prod_for_non_staff(auth_client):
+    res = auth_client.get("/api/exercises/audit/")
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(ENVIRONMENT="dev")
+def test_audit_returns_skills_in_dev(auth_client):
+    res = auth_client.get("/api/exercises/audit/")
+    assert res.status_code == 200
+    body = res.json()
+    assert "skills" in body
+    assert "meta" in body
+    assert len(body["skills"]) > 0
+    sample = next(iter(body["skills"].values()))
+    for key in ("id", "label", "grade", "template_count", "status"):
+        assert key in sample
+
+
+@pytest.mark.django_db
+@override_settings(ENVIRONMENT="dev")
+def test_skill_detail_lists_templates(auth_client):
+    res = auth_client.get("/api/exercises/audit/skill/add_avec_retenue_20/")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["skill"]["id"] == "add_avec_retenue_20"
+    assert isinstance(body["templates"], list)
+    assert len(body["templates"]) > 0
+    tpl = body["templates"][0]
+    for key in ("id", "difficulty", "input_type", "template_type"):
+        assert key in tpl
+
+
+@pytest.mark.django_db
+@override_settings(ENVIRONMENT="dev")
+def test_skill_detail_404_for_unknown_skill(auth_client):
+    res = auth_client.get("/api/exercises/audit/skill/__nope__/")
+    assert res.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(ENVIRONMENT="dev")
+def test_template_preview_returns_prompt_and_answer(auth_client):
+    from apps.exercises.models import ExerciseTemplate
+
+    tpl = ExerciseTemplate.objects.first()
+    res = auth_client.get(f"/api/exercises/templates/{tpl.id}/preview/")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["template_id"] == tpl.id
+    assert "prompt" in body or "error" in body
+    if "error" not in body:
+        assert "answer" in body
+        assert "params" in body
+
+
+@pytest.mark.django_db
+@override_settings(ENVIRONMENT="prod")
+def test_template_preview_hidden_in_prod(auth_client):
+    from apps.exercises.models import ExerciseTemplate
+
+    tpl = ExerciseTemplate.objects.first()
+    res = auth_client.get(f"/api/exercises/templates/{tpl.id}/preview/")
+    assert res.status_code == 404

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react"
-import { Routes, Route, useNavigate, Navigate, useLocation } from "react-router"
+import { Routes, Route, useNavigate, Navigate, useLocation, useParams } from "react-router"
 import { useAuthStore } from "./stores/authStore"
 import WelcomeScreen from "./components/screens/WelcomeScreen"
 import LandingScreen from "./components/screens/LandingScreen"
@@ -15,6 +15,8 @@ import ExamScreen from "./components/screens/ExamScreen"
 import ProfileScreen from "./components/screens/ProfileScreen"
 import DebugInputsScreen from "./components/screens/DebugInputsScreen"
 import DebugPlantsScreen from "./components/screens/DebugPlantsScreen"
+import AtelierScreen from "./components/screens/AtelierScreen"
+import AtelierSkillScreen from "./components/screens/AtelierSkillScreen"
 import NotFoundScreen from "./components/screens/NotFoundScreen"
 import HistoryScreen from "./components/screens/HistoryScreen"
 import DiagnosticReviewScreen from "./components/screens/DiagnosticReviewScreen"
@@ -45,6 +47,11 @@ function RootRoute() {
   const { user, loading } = useAuthStore()
   if (loading && !user) return <BootLoader />
   return user ? <WelcomeScreen /> : <LandingScreen />
+}
+
+function AtelierSkillScreenKeyed() {
+  const { skillId } = useParams()
+  return <AtelierSkillScreen key={skillId} />
 }
 
 export default function App() {
@@ -83,6 +90,15 @@ export default function App() {
         )}
         {import.meta.env.VITE_ENVIRONMENT === "dev" && (
           <Route path="/debug/plants" element={<RequireAuth><DebugPlantsScreen /></RequireAuth>} />
+        )}
+        {import.meta.env.VITE_ENVIRONMENT === "dev" && (
+          <Route path="/atelier" element={<RequireAuth><AtelierScreen /></RequireAuth>} />
+        )}
+        {import.meta.env.VITE_ENVIRONMENT === "dev" && (
+          <Route
+            path="/atelier/skill/:skillId"
+            element={<RequireAuth><AtelierSkillScreenKeyed /></RequireAuth>}
+          />
         )}
         <Route path="*" element={<NotFoundScreen />} />
       </Routes>

--- a/frontend/src/api/atelier.js
+++ b/frontend/src/api/atelier.js
@@ -1,0 +1,8 @@
+import { api } from "./client"
+
+export const atelierApi = {
+  audit: () => api.get("/exercises/audit/"),
+  skill: (skillId) => api.get(`/exercises/audit/skill/${encodeURIComponent(skillId)}/`),
+  preview: (templateId) =>
+    api.get(`/exercises/templates/${encodeURIComponent(templateId)}/preview/`),
+}

--- a/frontend/src/components/screens/AtelierScreen.jsx
+++ b/frontend/src/components/screens/AtelierScreen.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from "react"
-import { Link, useNavigate } from "react-router"
+import { useNavigate } from "react-router"
 import AppShell from "../layout/AppShell"
 import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarBack, TopBarLink } from "../layout/TopBarActions"
 import Loader from "../ui/Loader"
 import { atelierApi } from "../../api/atelier"
 
@@ -130,26 +132,24 @@ export default function AtelierScreen() {
   }, [data])
 
   return (
-    <AppShell surface="plain">
+    <AppShell
+      surface="plain"
+      topBar={
+        <TopBar
+          leading={<TopBarBack to="/" label="Serre" />}
+          title="Atelier"
+          trailing={<TopBarLink to="/debug/inputs" icon="tune">Types d'inputs</TopBarLink>}
+        />
+      }
+    >
       <Page maxWidth="full">
-        <div className="flex items-center justify-between mb-6">
-          <div>
-            <h1 className="font-display text-3xl font-semibold text-bark">Atelier</h1>
-            <p className="text-sm text-stem mt-1">
-              Santé des templates par compétence (P1 → P6).
-              {data?.meta?.source === "live" && (
-                <span className="ml-2 chip chip-honey">données live (pas d'audit)</span>
-              )}
-            </p>
-          </div>
-          <div className="flex gap-3">
-            <Link to="/debug/inputs" className="navlink">
-              Types d'inputs
-            </Link>
-            <Link to="/" className="navlink">
-              Retour
-            </Link>
-          </div>
+        <div className="mb-6">
+          <p className="text-sm text-stem">
+            Santé des templates par compétence (P1 → P6).
+            {data?.meta?.source === "live" && (
+              <span className="ml-2 chip chip-honey">données live (pas d'audit)</span>
+            )}
+          </p>
         </div>
 
         {loading && (

--- a/frontend/src/components/screens/AtelierScreen.jsx
+++ b/frontend/src/components/screens/AtelierScreen.jsx
@@ -1,0 +1,217 @@
+import { useEffect, useMemo, useState } from "react"
+import { Link, useNavigate } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import Loader from "../ui/Loader"
+import { atelierApi } from "../../api/atelier"
+
+const GRADES = ["P1", "P2", "P3", "P4", "P5", "P6"]
+
+const STATUS_STYLE = {
+  ok: { bg: "bg-sage-leaf/60", border: "border-sage", dot: "bg-sage-deep", label: "OK" },
+  single_tier: {
+    bg: "bg-honey-soft/70",
+    border: "border-honey",
+    dot: "bg-honey",
+    label: "1 palier",
+  },
+  thin: { bg: "bg-honey/50", border: "border-honey", dot: "bg-honey", label: "Maigre" },
+  broken: { bg: "bg-rose-soft", border: "border-rose", dot: "bg-rose", label: "Cassé" },
+  no_coverage: {
+    bg: "bg-mist",
+    border: "border-bark/10",
+    dot: "bg-bark/20",
+    label: "Sans template",
+  },
+}
+
+const FILTERS = [
+  { id: "all", label: "Tout" },
+  { id: "broken", label: "Cassés" },
+  { id: "thin", label: "Maigres" },
+  { id: "single_tier", label: "1 palier" },
+  { id: "ok", label: "OK" },
+]
+
+function statusStyle(status) {
+  return STATUS_STYLE[status] ?? STATUS_STYLE.no_coverage
+}
+
+function SkillCell({ skill, onClick }) {
+  const style = statusStyle(skill.status)
+  const score = skill.avg_score
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${style.bg} border ${style.border} rounded-xl px-3 py-2.5 text-left transition hover:-translate-y-px hover:shadow-leaf w-full`}
+    >
+      <div className="flex items-start gap-2">
+        <span className={`mt-1.5 h-2 w-2 rounded-full ${style.dot}`} aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <div className="text-sm font-medium text-bark truncate" title={skill.label}>
+            {skill.label}
+          </div>
+          <div className="mt-0.5 text-xs text-stem font-mono">
+            {skill.template_count} tpl · {skill.total_variants ?? "—"} var
+            {skill.difficulty_tiers?.length ? ` · d${skill.difficulty_tiers.join("")}` : ""}
+          </div>
+          {score != null && (
+            <div className="mt-0.5 text-xs text-stem">score {score}</div>
+          )}
+        </div>
+      </div>
+    </button>
+  )
+}
+
+function StatCard({ label, value, tone = "bark" }) {
+  const toneClass = {
+    bark: "text-bark",
+    sage: "text-sage-deep",
+    rose: "text-rose",
+    honey: "text-honey",
+  }[tone]
+  return (
+    <div className="specimen px-4 py-3">
+      <div className="text-xs uppercase tracking-wide text-stem">{label}</div>
+      <div className={`mt-1 font-display text-2xl ${toneClass}`}>{value}</div>
+    </div>
+  )
+}
+
+export default function AtelierScreen() {
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+  const [filter, setFilter] = useState("all")
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    let cancelled = false
+    atelierApi
+      .audit()
+      .then((d) => {
+        if (!cancelled) setData(d)
+      })
+      .catch((e) => {
+        if (!cancelled) setError(e.message || "Erreur")
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const byGrade = useMemo(() => {
+    if (!data) return {}
+    const out = Object.fromEntries(GRADES.map((g) => [g, []]))
+    for (const skill of Object.values(data.skills || {})) {
+      const grade = GRADES.includes(skill.grade) ? skill.grade : null
+      if (!grade) continue
+      if (filter !== "all" && skill.status !== filter) continue
+      out[grade].push(skill)
+    }
+    for (const g of GRADES) {
+      out[g].sort((a, b) => a.label.localeCompare(b.label, "fr"))
+    }
+    return out
+  }, [data, filter])
+
+  const counts = useMemo(() => {
+    const c = { total: 0, ok: 0, broken: 0, thin: 0, single_tier: 0, no_coverage: 0 }
+    for (const s of Object.values(data?.skills || {})) {
+      c.total += 1
+      c[s.status] = (c[s.status] ?? 0) + 1
+    }
+    return c
+  }, [data])
+
+  return (
+    <AppShell surface="plain">
+      <Page maxWidth="full">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="font-display text-3xl font-semibold text-bark">Atelier</h1>
+            <p className="text-sm text-stem mt-1">
+              Santé des templates par compétence (P1 → P6).
+              {data?.meta?.source === "live" && (
+                <span className="ml-2 chip chip-honey">données live (pas d'audit)</span>
+              )}
+            </p>
+          </div>
+          <div className="flex gap-3">
+            <Link to="/debug/inputs" className="navlink">
+              Types d'inputs
+            </Link>
+            <Link to="/" className="navlink">
+              Retour
+            </Link>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="py-16">
+            <Loader message="Chargement…" />
+          </div>
+        )}
+        {error && <p className="text-center text-rose">Erreur : {error}</p>}
+
+        {data && !loading && (
+          <>
+            <div className="grid grid-cols-2 md:grid-cols-6 gap-3 mb-6">
+              <StatCard label="Compétences" value={counts.total} />
+              <StatCard label="OK" value={counts.ok} tone="sage" />
+              <StatCard label="1 palier" value={counts.single_tier} tone="honey" />
+              <StatCard label="Maigres" value={counts.thin} tone="honey" />
+              <StatCard label="Cassés" value={counts.broken} tone="rose" />
+              <StatCard label="Sans couverture" value={counts.no_coverage} />
+            </div>
+
+            <div className="flex flex-wrap gap-2 mb-4">
+              {FILTERS.map((f) => (
+                <button
+                  key={f.id}
+                  type="button"
+                  onClick={() => setFilter(f.id)}
+                  className={`pill ${filter === f.id ? "" : "pill-ghost"} px-3 py-1.5 text-xs`}
+                >
+                  {f.label}
+                </button>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4">
+              {GRADES.map((grade) => (
+                <section key={grade}>
+                  <div className="text-xs uppercase tracking-wider text-stem font-medium mb-2 pb-1 border-b border-bark/10">
+                    {grade}
+                    <span className="ml-2 text-bark/50 font-mono normal-case">
+                      {byGrade[grade]?.length ?? 0}
+                    </span>
+                  </div>
+                  <div className="flex flex-col gap-2">
+                    {(byGrade[grade] || []).map((skill) => (
+                      <SkillCell
+                        key={skill.id}
+                        skill={skill}
+                        onClick={() =>
+                          navigate(`/atelier/skill/${encodeURIComponent(skill.id)}`)
+                        }
+                      />
+                    ))}
+                    {(byGrade[grade] || []).length === 0 && (
+                      <div className="text-xs text-stem/60 italic">—</div>
+                    )}
+                  </div>
+                </section>
+              ))}
+            </div>
+          </>
+        )}
+      </Page>
+    </AppShell>
+  )
+}

--- a/frontend/src/components/screens/AtelierSkillScreen.jsx
+++ b/frontend/src/components/screens/AtelierSkillScreen.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from "react"
-import { Link, useParams } from "react-router"
+import { useParams } from "react-router"
 import AppShell from "../layout/AppShell"
 import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarBack } from "../layout/TopBarActions"
 import Loader from "../ui/Loader"
 import { atelierApi } from "../../api/atelier"
 
@@ -177,29 +179,29 @@ export default function AtelierSkillScreen() {
   }, [skillId])
 
   return (
-    <AppShell surface="plain">
+    <AppShell
+      surface="plain"
+      topBar={
+        <TopBar leading={<TopBarBack to="/atelier" label="Atelier" />} title="Compétence" />
+      }
+    >
       <Page maxWidth="3xl">
-        <div className="flex items-center justify-between mb-6">
-          <div className="min-w-0">
-            <Link to="/atelier" className="text-xs text-stem hover:text-bark">
-              ← Atelier
-            </Link>
-            <h1 className="font-display text-2xl md:text-3xl font-semibold text-bark mt-1 truncate">
-              {data?.skill?.label || skillId}
-            </h1>
-            <div className="mt-1 flex items-center gap-2 text-xs text-stem flex-wrap">
-              <span className="chip">{data?.skill?.grade || "—"}</span>
-              <code className="font-mono">{skillId}</code>
-              {data?.summary?.status && (
-                <span className="chip chip-sky">{data.summary.status}</span>
-              )}
-              {data?.summary?.avg_score != null && (
-                <span>· score moyen {data.summary.avg_score}</span>
-              )}
-              {data?.summary?.total_variants != null && (
-                <span>· {data.summary.total_variants} variantes</span>
-              )}
-            </div>
+        <div className="mb-6 min-w-0">
+          <h1 className="font-display text-2xl md:text-3xl font-semibold text-bark truncate">
+            {data?.skill?.label || skillId}
+          </h1>
+          <div className="mt-1 flex items-center gap-2 text-xs text-stem flex-wrap">
+            <span className="chip">{data?.skill?.grade || "—"}</span>
+            <code className="font-mono">{skillId}</code>
+            {data?.summary?.status && (
+              <span className="chip chip-sky">{data.summary.status}</span>
+            )}
+            {data?.summary?.avg_score != null && (
+              <span>· score moyen {data.summary.avg_score}</span>
+            )}
+            {data?.summary?.total_variants != null && (
+              <span>· {data.summary.total_variants} variantes</span>
+            )}
           </div>
         </div>
 

--- a/frontend/src/components/screens/AtelierSkillScreen.jsx
+++ b/frontend/src/components/screens/AtelierSkillScreen.jsx
@@ -1,0 +1,228 @@
+import { useEffect, useState } from "react"
+import { Link, useParams } from "react-router"
+import AppShell from "../layout/AppShell"
+import Page from "../layout/Page"
+import Loader from "../ui/Loader"
+import { atelierApi } from "../../api/atelier"
+
+function scoreTone(score) {
+  if (score == null) return "text-stem"
+  if (score >= 80) return "text-sage-deep"
+  if (score >= 60) return "text-honey"
+  return "text-rose"
+}
+
+function formatAnswer(answer) {
+  if (answer == null) return "—"
+  if (typeof answer === "object") return JSON.stringify(answer)
+  return String(answer)
+}
+
+function TemplateRow({ tpl }) {
+  const [preview, setPreview] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+
+  const generate = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const p = await atelierApi.preview(tpl.id)
+      setPreview(p)
+    } catch (e) {
+      setError(e.message || "Erreur")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const audit = tpl.score != null
+  const flags = tpl.flags || {}
+  const flagsList = [
+    flags.critical_bug && "bug critique",
+    flags.broken_constraints && "contraintes cassées",
+    flags.degenerate && "variantes dégénérées",
+    flags.thin && "maigre",
+  ].filter(Boolean)
+
+  return (
+    <article className="specimen p-4">
+      <header className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <code className="font-mono text-sm text-bark">{tpl.id}</code>
+            <span className="chip">d{tpl.difficulty}</span>
+            <span className="chip chip-sky">{tpl.input_type}</span>
+            {tpl.template_type && <span className="chip">{tpl.template_type}</span>}
+            {tpl.operation && <span className="chip">{tpl.operation}</span>}
+          </div>
+          <div className="mt-2 text-xs text-stem font-mono truncate" title={tpl.prompt_template}>
+            {tpl.prompt_template || <span className="italic">sans prompt_template</span>}
+          </div>
+        </div>
+        <div className="text-right shrink-0">
+          {audit && (
+            <>
+              <div className={`font-display text-xl ${scoreTone(tpl.score)}`}>
+                {tpl.score}
+                <span className="text-xs text-stem font-body">/100</span>
+              </div>
+              <div className="text-xs text-stem">{tpl.variant_count ?? "—"} variantes</div>
+            </>
+          )}
+        </div>
+      </header>
+
+      {(tpl.score_reasons?.length > 0 || flagsList.length > 0) && (
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {flagsList.map((f) => (
+            <span key={f} className="chip chip-bark">{f}</span>
+          ))}
+          {tpl.score_reasons?.map((r) => (
+            <span key={r} className="text-xs text-stem">· {r}</span>
+          ))}
+        </div>
+      )}
+
+      {flags.fix && (
+        <div className="mt-2 text-xs text-sage-deep bg-sage-pale/40 rounded-lg px-3 py-2">
+          <span className="font-medium">Fix&nbsp;:</span> {flags.fix}
+        </div>
+      )}
+
+      <div className="mt-3 flex items-center gap-3">
+        <button
+          type="button"
+          onClick={generate}
+          disabled={loading}
+          className="pill pill-ghost px-3 py-1.5 text-xs"
+        >
+          {loading ? "…" : "Générer"}
+        </button>
+        {tpl.sample_prompts?.length > 0 && !preview && !loading && (
+          <span className="text-xs text-stem italic">
+            exemples audit&nbsp;: {tpl.sample_prompts.length}
+          </span>
+        )}
+      </div>
+
+      {!preview && tpl.sample_prompts?.length > 0 && (
+        <div className="mt-3 grid gap-2">
+          {tpl.sample_prompts.slice(0, 3).map((p, i) => (
+            <div key={i} className="text-xs font-mono bg-mist/60 rounded px-2 py-1.5">
+              <span className="text-bark">{p}</span>
+              {tpl.sample_answers?.[i] != null && (
+                <span className="text-stem ml-2">→ {formatAnswer(tpl.sample_answers[i])}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && <p className="mt-3 text-xs text-rose">Erreur : {error}</p>}
+
+      {preview && (
+        <div className="mt-3 bg-chalk border border-bark/10 rounded-lg p-3">
+          {preview.error ? (
+            <div className="text-xs text-rose font-mono">{preview.error}</div>
+          ) : (
+            <>
+              <div className="text-sm text-bark">{preview.prompt}</div>
+              <div className="mt-2 text-xs text-sage-deep">
+                <span className="text-stem">réponse&nbsp;: </span>
+                <span className="font-mono">{formatAnswer(preview.answer)}</span>
+              </div>
+              <details className="mt-2">
+                <summary className="text-xs text-stem cursor-pointer">params</summary>
+                <pre className="mt-1 text-xs font-mono text-stem overflow-x-auto">
+                  {JSON.stringify(preview.params, null, 2)}
+                </pre>
+              </details>
+            </>
+          )}
+        </div>
+      )}
+    </article>
+  )
+}
+
+export default function AtelierSkillScreen() {
+  const { skillId } = useParams()
+  const [data, setData] = useState(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  useEffect(() => {
+    let cancelled = false
+    atelierApi
+      .skill(skillId)
+      .then((d) => {
+        if (!cancelled) {
+          setData(d)
+          setError(null)
+        }
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          setData(null)
+          setError(e.message || "Erreur")
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [skillId])
+
+  return (
+    <AppShell surface="plain">
+      <Page maxWidth="3xl">
+        <div className="flex items-center justify-between mb-6">
+          <div className="min-w-0">
+            <Link to="/atelier" className="text-xs text-stem hover:text-bark">
+              ← Atelier
+            </Link>
+            <h1 className="font-display text-2xl md:text-3xl font-semibold text-bark mt-1 truncate">
+              {data?.skill?.label || skillId}
+            </h1>
+            <div className="mt-1 flex items-center gap-2 text-xs text-stem flex-wrap">
+              <span className="chip">{data?.skill?.grade || "—"}</span>
+              <code className="font-mono">{skillId}</code>
+              {data?.summary?.status && (
+                <span className="chip chip-sky">{data.summary.status}</span>
+              )}
+              {data?.summary?.avg_score != null && (
+                <span>· score moyen {data.summary.avg_score}</span>
+              )}
+              {data?.summary?.total_variants != null && (
+                <span>· {data.summary.total_variants} variantes</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {loading && (
+          <div className="py-16">
+            <Loader message="Chargement…" />
+          </div>
+        )}
+        {error && <p className="text-center text-rose">Erreur : {error}</p>}
+
+        {data && !loading && (
+          <div className="grid gap-4">
+            {data.templates.map((tpl) => (
+              <TemplateRow key={tpl.id} tpl={tpl} />
+            ))}
+            {data.templates.length === 0 && (
+              <div className="specimen p-6 text-center text-stem">
+                Aucun template pour cette compétence.
+              </div>
+            )}
+          </div>
+        )}
+      </Page>
+    </AppShell>
+  )
+}

--- a/frontend/src/components/screens/DebugInputsScreen.jsx
+++ b/frontend/src/components/screens/DebugInputsScreen.jsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react"
-import { Link } from "react-router"
 import AppShell from "../layout/AppShell"
 import Page from "../layout/Page"
+import TopBar from "../layout/TopBar"
+import { TopBarBack, TopBarButton } from "../layout/TopBarActions"
 import { api } from "../../api/client"
 import Loader from "../ui/Loader"
 import ExerciseCard from "../exercises/ExerciseCard"
@@ -36,21 +37,17 @@ export default function DebugInputsScreen() {
   }
 
   return (
-    <AppShell surface="plain">
+    <AppShell
+      surface="plain"
+      topBar={
+        <TopBar
+          leading={<TopBarBack to="/atelier" label="Atelier" />}
+          title="Types d'exercices"
+          trailing={<TopBarButton onClick={load} icon="refresh">Régénérer</TopBarButton>}
+        />
+      }
+    >
       <Page maxWidth="xl">
-        <div className="flex items-center justify-between mb-6">
-          <h1 className="font-display text-3xl font-semibold text-bark">
-            Debug — Types d'exercices
-          </h1>
-          <div className="flex gap-3">
-            <button onClick={load} className="navlink">
-              Régénérer
-            </button>
-            <Link to="/" className="navlink">
-              Retour
-            </Link>
-          </div>
-        </div>
 
         {loading && (
           <div className="py-10">


### PR DESCRIPTION
Closes #156. Closes #182.

## Summary
- `/atelier` (dev-only): 6-column P1→P6 skill-health grid with JARDIN-palette status dots, stat cards (OK / 1 palier / Maigres / Cassés / Sans couverture), and filter pills.
- `/atelier/skill/:skillId` (dev-only): lists every template for the skill with id, difficulty, input_type, template_type, audit score (when available), flags, and a **Générer** button that calls the generator and renders `prompt` + `réponse` + `params`.
- Three new API endpoints, all gated on `ENVIRONMENT=dev` or `user.is_staff`: `GET /api/exercises/audit/`, `GET /api/exercises/audit/skill/<id>/`, `GET /api/exercises/templates/<id>/preview/`.
- Audit endpoint reads `artifacts/audit/combined.json` when present; falls back to a live DB-derived summary otherwise (so the Atelier works without the audit tooling having been run).

## Out of scope
- Live YAML param tweaking (#156 hints at it — kept for a follow-up; this PR does previews only, no mutation).
- Wiring `artifacts/audit/` into the backend container so the full audit scores flow through. Dev ergonomics only; easy follow-up (one volume mount).

## Test plan
- [x] `uv run pytest tests/test_atelier_api.py` — 7 tests (auth, dev gating, shape of each endpoint) green
- [x] Full backend suite — 171 pass (one unrelated pre-existing failure on `test_csrf_endpoint_sets_cookie`, a worktree-.env side effect, not caused by this PR)
- [x] `npm run lint` green
- [x] `npm run build` green
- [x] Playwright smoke test against the running stack: login → `/atelier` renders 110 skills in 6 columns → click cell → skill detail shows 2 templates → click Générer → `8 + 4 = ?` / `réponse : 12` rendered (no console errors, no 4xx/5xx)

🤖 Generated with [Claude Code](https://claude.com/claude-code)