### PR TITLE
fix(#167): route silent catches through Sentry

### DIFF
--- a/frontend/src/components/screens/LoginScreen.jsx
+++ b/frontend/src/components/screens/LoginScreen.jsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { Link, useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
 import { startGoogleLogin } from "../../lib/googleOAuth"
+import { captureException, isClientError } from "../../lib/errors"
 import AppShell from "../layout/AppShell"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
@@ -23,8 +24,9 @@ export default function LoginScreen() {
     try {
       await login(email, password)
       navigate("/children")
-    } catch {
+    } catch (err) {
       setError("Email ou mot de passe incorrect")
+      if (!isClientError(err)) captureException(err, { where: "LoginScreen.onSubmit" })
     } finally {
       setBusy(false)
     }

--- a/frontend/src/components/screens/ParametresScreen.jsx
+++ b/frontend/src/components/screens/ParametresScreen.jsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react"
 import { useNavigate } from "react-router"
 import { useAuthStore } from "../../stores/authStore"
+import { captureException, isClientError } from "../../lib/errors"
 import Button from "../ui/Button"
 import Card from "../ui/Card"
 import Icon from "../ui/Icon"
@@ -71,6 +72,7 @@ function AutosaveField({
     } catch (err) {
       setState("error")
       setError(parseFieldError(err, label.toLowerCase()))
+      if (!isClientError(err)) captureException(err, { where: "AutosaveField.commit", label })
     }
   }
 
@@ -134,7 +136,10 @@ function PasswordDrawer() {
       if (data?.old_password) setError("Mot de passe actuel incorrect.")
       else if (data?.new_password2) setError(data.new_password2[0])
       else if (data?.new_password1) setError(data.new_password1[0])
-      else setError("Impossible de modifier le mot de passe.")
+      else {
+        setError("Impossible de modifier le mot de passe.")
+        if (!isClientError(err)) captureException(err, { where: "ParametresScreen.password" })
+      }
     }
   }
 
@@ -222,7 +227,8 @@ function ChildRow({ child, index }) {
     setRemoving(true)
     try {
       await removeChild(child.id)
-    } catch {
+    } catch (err) {
+      captureException(err, { where: "ChildRow.onDelete", childId: child.id })
       setRemoving(false)
       setConfirming(false)
     }

--- a/frontend/src/lib/errors.js
+++ b/frontend/src/lib/errors.js
@@ -1,0 +1,17 @@
+import * as Sentry from "@sentry/react"
+
+const dsnEnabled = Boolean(import.meta.env.VITE_SENTRY_DSN)
+
+export function captureException(err, context) {
+  if (!dsnEnabled) return
+  Sentry.captureException(err, context ? { extra: context } : undefined)
+}
+
+export function isAuthError(err) {
+  return err?.status === 401 || err?.status === 403
+}
+
+export function isClientError(err) {
+  const s = err?.status
+  return typeof s === "number" && s >= 400 && s < 500
+}

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -2,13 +2,15 @@ import { create } from "zustand"
 import { api } from "../api/client"
 import { accountApi } from "../api/account"
 import { studentsApi } from "../api/students"
+import { captureException, isAuthError } from "../lib/errors"
 
 const STORAGE_KEY = "pedagogia.selectedChildId"
 
 const readSelected = () => {
   try {
     return typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null
-  } catch {
+  } catch (err) {
+    captureException(err, { where: "authStore.readSelected" })
     return null
   }
 }
@@ -18,7 +20,9 @@ const writeSelected = (id) => {
     if (typeof localStorage === "undefined") return
     if (id) localStorage.setItem(STORAGE_KEY, id)
     else localStorage.removeItem(STORAGE_KEY)
-  } catch { /* ignore */ }
+  } catch (err) {
+    captureException(err, { where: "authStore.writeSelected" })
+  }
 }
 
 export const useAuthStore = create((set, get) => ({
@@ -44,9 +48,10 @@ export const useAuthStore = create((set, get) => ({
         loading: false
       })
     } catch (err) {
-      if (err.status === 401 || err.status === 403) {
+      if (isAuthError(err)) {
         set({ user: null, children: [], selectedChildId: null, loading: false })
       } else {
+        captureException(err, { where: "authStore.bootstrap" })
         set({ error: err.message, loading: false })
       }
     }
@@ -76,7 +81,11 @@ export const useAuthStore = create((set, get) => ({
   },
 
   logout: async () => {
-    try { await api.post("/auth/logout/") } catch { /* ignore */ }
+    try {
+      await api.post("/auth/logout/")
+    } catch (err) {
+      captureException(err, { where: "authStore.logout" })
+    }
     writeSelected(null)
     set({ user: null, children: [], selectedChildId: null })
   },

--- a/frontend/src/stores/sessionStore.js
+++ b/frontend/src/stores/sessionStore.js
@@ -1,6 +1,7 @@
 import { create } from "zustand"
 import { exercisesApi } from "../api/exercises"
 import { invalidateSkillTree } from "../lib/queryClient"
+import { captureException } from "../lib/errors"
 import { useAuthStore } from "./authStore"
 import { useBadgeStore } from "./badgeStore"
 
@@ -89,7 +90,11 @@ export const useSessionStore = create((set, get) => ({
   stop: async () => {
     const { sessionId } = get()
     if (sessionId) {
-      try { await exercisesApi.endSession(sessionId) } catch { /* ignore */ }
+      try {
+        await exercisesApi.endSession(sessionId)
+      } catch (err) {
+        captureException(err, { where: "sessionStore.stop", sessionId })
+      }
     }
     set({ ...INITIAL })
   },


### PR DESCRIPTION
## Summary
- New `src/lib/errors.js` — thin wrapper around `Sentry.captureException` that no-ops when `VITE_SENTRY_DSN` is unset, so dev/local stays quiet.
- Swallowed `catch {}` and `/* ignore */` in `src/stores/` and `src/components/screens/` now route through `captureException(err, { where })`:
  - `authStore` — bootstrap (non-4xx only), logout, `localStorage` read/write
  - `sessionStore.stop` — best-effort `endSession`
  - `LoginScreen.onSubmit` — keep the "mauvais identifiants" UI, capture only non-4xx
  - `ParametresScreen` — password drawer, autosave field, child-delete: capture unexpected (non-4xx) errors while preserving existing 4xx UI feedback
- Debug-only `JSON.parse` catches in `DebugInputsScreen` left alone — expected parse failures, not prod noise.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [ ] CI E2E suite (Playwright browsers not available in local container)
- [ ] Manual staging check: trigger a backend 500 on login / password change / child delete → confirm Sentry event lands

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)