### PR TITLE
fix(#195): atelier PDF rendu blanc + stylet inutilisable sur iOS WebKit

### DIFF
--- a/frontend/src/components/screens/AtelierPdfReader.jsx
+++ b/frontend/src/components/screens/AtelierPdfReader.jsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
-import * as pdfjsLib from "pdfjs-dist"
-import pdfWorkerUrl from "pdfjs-dist/build/pdf.worker.mjs?url"
+import * as pdfjsLib from "pdfjs-dist/legacy/build/pdf.mjs"
+import pdfWorkerUrl from "pdfjs-dist/legacy/build/pdf.worker.mjs?url"
 import Button from "../ui/Button"
 import Icon from "../ui/Icon"
 import Loader from "../ui/Loader"

--- a/frontend/src/components/ui/StyletCanvas.jsx
+++ b/frontend/src/components/ui/StyletCanvas.jsx
@@ -224,7 +224,13 @@ const StyletCanvas = forwardRef(function StyletCanvas(
           ref={canvasRef}
           data-testid="stylet-canvas"
           className="block w-full h-full"
-          style={{ background: "transparent" }}
+          style={{
+            background: "transparent",
+            touchAction: "none",
+            WebkitUserSelect: "none",
+            userSelect: "none",
+            WebkitTouchCallout: "none",
+          }}
           onPointerDown={onPointerDown}
           onPointerMove={onPointerMove}
           onPointerUp={onPointerUp}


### PR DESCRIPTION
## Summary
Deux bugs distincts confirmés sur iOS Safari + Chrome iOS + Brave iOS (tous WebKit, iPadOS 18.7) :

1. **Canvas PDF blanc** — `pdfjs-dist@5` utilise un build "modern" dont le rendu canvas échoue silencieusement sur WebKit. Bascule sur le build `legacy` recommandé upstream.
2. **Stylet déclenche un scroll** au lieu de tracer — sur iOS, le système de gestures décide du scroll avant les pointer events. Le wrapper avait déjà `touch-action: none` mais il faut aussi le poser **directement sur le `<canvas>`** + inhiber `user-select` / `WebkitTouchCallout`.

## Test plan
- [x] Frontend build ✅ (worker passe à 2.3 Mo legacy, attendu)
- [ ] Test manuel sur iPad Safari : ouvrir Atelier PDF → page se rend → écrire au doigt → trace au lieu de scroller
- [ ] Test manuel desktop (régression) : Chrome/Firefox desktop, le PDF se rend toujours, le stylet fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)