### PR TITLE
fix(#204): mic modal copy — Chrome dropped the lock icon

### DIFF
--- a/frontend/src/components/chat/MicPermissionModal.jsx
+++ b/frontend/src/components/chat/MicPermissionModal.jsx
@@ -54,20 +54,21 @@ function getRecoverySteps(family) {
     case "android_chrome":
     case "android_firefox":
       return [
-        "Touche le **cadenas** à gauche de la barre d'adresse",
+        "Touche l'icône à gauche de l'URL (**cadenas** ou **réglages**)",
         "Choisis **Autorisations**",
         "Active **Microphone**",
         "Recharge la page"
       ]
     case "safari":
       return [
-        "Ouvre **Safari → Réglages → Sites web → Microphone**",
+        "Ouvre le menu **Safari → Réglages → Sites web**",
+        "Clique sur **Microphone** dans la colonne de gauche",
         "Trouve **collegia.be** et choisis **Autoriser**",
         "Recharge la page"
       ]
     case "firefox":
       return [
-        "Clique sur le **cadenas** à gauche de la barre d'adresse",
+        "Clique sur le **cadenas** à gauche de l'URL",
         "À côté de « Utiliser le microphone », clique sur la **croix** pour effacer le blocage",
         "Recharge la page et réautorise"
       ]
@@ -75,8 +76,9 @@ function getRecoverySteps(family) {
     case "edge":
     default:
       return [
-        "Clique sur le **cadenas** à gauche de la barre d'adresse",
-        "Trouve **Microphone** et choisis **Autoriser**",
+        "Clique sur l'icône à gauche de l'URL — un **bouton réglages** (trois curseurs) sur Chrome récent, sinon un **cadenas**",
+        "Choisis **Paramètres du site** (ou **Autorisations**)",
+        "Mets **Microphone** sur **Autoriser**",
         "Recharge la page"
       ]
   }


### PR DESCRIPTION
## Summary
- Chrome 117+ replaced the address-bar lock with a **tune / sliders** icon; Safari macOS often hides the URL-bar icon entirely. The recovery instructions in #205 still said "cadenas à gauche de la barre d'adresse" — users don't see one.
- Update \`getRecoverySteps\` in \`MicPermissionModal\`:
  - Chromium (Chrome/Edge desktop): describe both states ("bouton **réglages** trois curseurs sur Chrome récent, sinon un **cadenas**") and use the actual menu label "Paramètres du site"
  - Safari macOS: drop the cadenas reference, point straight to **Safari → Réglages → Sites web → Microphone**
  - Android: generic "icône à gauche de l'URL (cadenas ou réglages)"
  - iOS / Firefox: unchanged (AA menu and lock are still accurate)

## Test plan
- [ ] In Chrome, block mic → modal shows the tune-icon wording
- [ ] In Safari, block mic → modal points to Réglages → Sites web (no cadenas mention)
- [ ] In Firefox, modal still mentions the lock + cross-to-clear flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)