### PR TITLE
fix(#208): palm-scroll au lever du stylet sur iPad

### DIFF
--- a/frontend/src/components/screens/AtelierPdfReader.jsx
+++ b/frontend/src/components/screens/AtelierPdfReader.jsx
@@ -346,11 +346,15 @@ export default function AtelierPdfReader({ source }) {
               <div className="overflow-x-auto -mx-4 sm:-mx-6 px-4 sm:px-6 pb-1">
                 <div
                   className="relative rounded-2xl border border-sage/20 shadow-[var(--shadow-leaf)] bg-bone mx-auto"
-                  style={
-                    pageSize.width
+                  style={{
+                    ...(pageSize.width
                       ? { width: pageSize.width, height: pageSize.height }
-                      : undefined
-                  }
+                      : {}),
+                    touchAction: "none",
+                    WebkitUserSelect: "none",
+                    userSelect: "none",
+                    WebkitTouchCallout: "none",
+                  }}
                   data-testid="pdf-page-frame"
                 >
                   <canvas

--- a/frontend/src/components/ui/StyletCanvas.jsx
+++ b/frontend/src/components/ui/StyletCanvas.jsx
@@ -78,6 +78,7 @@ const StyletCanvas = forwardRef(function StyletCanvas(
   const historyRef = useRef([])
   const currentRef = useRef(null)
   const activePenRef = useRef(null)
+  const penLockUntilRef = useRef(0)
   const sizeRef = useRef({ cssW: 0, cssH: 0 })
   const [hasContent, setHasContent] = useState(false)
   const [canUndo, setCanUndo] = useState(false)
@@ -118,6 +119,14 @@ const StyletCanvas = forwardRef(function StyletCanvas(
     return () => ro.disconnect()
   }, [redraw])
 
+  useEffect(() => {
+    const block = (e) => {
+      if (Date.now() < penLockUntilRef.current && e.cancelable) e.preventDefault()
+    }
+    document.addEventListener("touchmove", block, { passive: false })
+    return () => document.removeEventListener("touchmove", block)
+  }, [])
+
   const localPoint = (event) => {
     const canvas = canvasRef.current
     const rect = canvas.getBoundingClientRect()
@@ -132,7 +141,10 @@ const StyletCanvas = forwardRef(function StyletCanvas(
   const onPointerDown = (event) => {
     const t = event.pointerType
     if (t === "touch" && activePenRef.current !== null) return
-    if (t === "pen") activePenRef.current = event.pointerId
+    if (t === "pen") {
+      activePenRef.current = event.pointerId
+      penLockUntilRef.current = Number.POSITIVE_INFINITY
+    }
     canvasRef.current.setPointerCapture?.(event.pointerId)
     event.preventDefault()
     currentRef.current = eraser
@@ -153,6 +165,7 @@ const StyletCanvas = forwardRef(function StyletCanvas(
     currentRef.current = null
     if (event.pointerType === "pen" && activePenRef.current === event.pointerId) {
       activePenRef.current = null
+      penLockUntilRef.current = Date.now() + 350
     }
     if (stroke && stroke.points.length > 0) {
       historyRef.current.push(strokesRef.current.slice())


### PR DESCRIPTION
## Summary
- StyletCanvas : fenêtre de "pen lock" (session stylet + 350 ms de grâce après pen-up) avec listener `touchmove` non-passif au niveau document qui `preventDefault` pendant la fenêtre — bloque le scroll que iOS résolvait au lever du stylet
- AtelierPdfReader : `touch-action: none` (et neutralisation user-select / callout WebKit) étendu du canvas au cadre de la page PDF, pour que la paume sur les marges n'enfile pas un scroll

Closes #208.

## Test plan
- [ ] Sur iPad + Apple Pencil : tracer un trait avec la paume posée, lever le stylet → pas de scroll
- [ ] Lever le stylet, paume toujours posée → pas de scroll dans les ~350 ms qui suivent
- [ ] Scroll vertical au doigt en dehors du cadre PDF reste fluide
- [ ] Vérifié sur Safari iOS / Chrome iOS / Brave iOS (iPadOS 18.7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)