### PR TITLE
fix(#197): use SMTP port 587 not 465 (Hetzner blocks 465)

### DIFF
--- a/backend/pedagogia/settings/base.py
+++ b/backend/pedagogia/settings/base.py
@@ -223,6 +223,8 @@ FRONTEND_URL = CORS_ALLOWED_ORIGINS[0].rstrip("/")
 
 # Email — Resend SMTP. With no API key the backend falls back to console so
 # local dev prints emails to logs instead of trying to authenticate.
+# Port 587 (STARTTLS) instead of 465 (SSL) because Hetzner blocks outbound
+# 465 by default — 587 is open and is Resend's recommended primary anyway.
 RESEND_API_KEY = env("RESEND_API_KEY")
 EMAIL_BACKEND = (
     "django.core.mail.backends.smtp.EmailBackend"
@@ -230,11 +232,12 @@ EMAIL_BACKEND = (
     else "django.core.mail.backends.console.EmailBackend"
 )
 EMAIL_HOST = "smtp.resend.com"
-EMAIL_PORT = 465
-EMAIL_USE_SSL = True
-EMAIL_USE_TLS = False
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
 EMAIL_HOST_USER = "resend"
 EMAIL_HOST_PASSWORD = RESEND_API_KEY
+EMAIL_TIMEOUT = 10
 DEFAULT_FROM_EMAIL = "CollegIA <noreply@send.collegia.be>"
 SERVER_EMAIL = DEFAULT_FROM_EMAIL
 


### PR DESCRIPTION
## Summary
Hetzner blocks outbound TCP 465 on cloud servers by default. Resend's SMTP listener on 465 hangs the connection, gunicorn's worker eventually times out and the user gets a 500 on registration with no email sent. Port **587** (STARTTLS) is open and is Resend's recommended primary anyway.

Also add `EMAIL_TIMEOUT=10` so future SMTP weirdness fails the request in 10s instead of killing the gunicorn worker.

## Repro on prod (before this PR)
```
$ ssh prod 'timeout 5 bash -c "exec 3<>/dev/tcp/smtp.resend.com/465" || echo BLOCKED'
BLOCKED
$ ssh prod 'timeout 5 bash -c "exec 3<>/dev/tcp/smtp.resend.com/587" && echo OPEN'
OPEN
```

Backend traceback at the moment of the 500: `socket.create_connection` → gunicorn `handle_abort` → `SystemExit: 1`.

## Test plan
- [x] Auth tests still pass (settings change, locmem backend in tests bypasses port choice)
- [ ] After deploy: register a real email on prod, confirm Resend dashboard shows the send + email arrives within ~10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)