### PR TITLE
fix(#197): catch duplicate-email registration as 400, not 500

### DIFF
--- a/backend/apps/accounts/serializers.py
+++ b/backend/apps/accounts/serializers.py
@@ -23,6 +23,18 @@ class UserRegisterSerializer(RegisterSerializer):
     username = None
     display_name = serializers.CharField(required=False, allow_blank=True, max_length=100)
 
+    def validate_email(self, email):
+        email = super().validate_email(email)
+        # Belt-and-suspenders: allauth's pre-flight duplicate check looks at the
+        # EmailAddress table first, but social-OAuth users can end up with an
+        # unverified EmailAddress row that the check skips — leaving a duplicate
+        # to surface as a 500 from the Postgres UNIQUE constraint. Catch it here.
+        if User.objects.filter(email__iexact=email).exists():
+            raise serializers.ValidationError(
+                "A user is already registered with this e-mail address."
+            )
+        return email
+
     def get_cleaned_data(self):
         data = super().get_cleaned_data()
         data["display_name"] = self.validated_data.get("display_name", "")

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -122,6 +122,29 @@ def test_resend_verification_email_issues_a_fresh_link():
 
 
 @pytest.mark.django_db
+def test_register_duplicate_email_returns_400_not_500(django_user_model):
+    """OAuth-created users can have an unverified EmailAddress row that
+    allauth's pre-flight duplicate check skips — without this guard the
+    duplicate hits the UNIQUE constraint at INSERT and surfaces as a 500."""
+    django_user_model.objects.create_user(email="taken@example.com", password="pw12345!")
+
+    res = APIClient().post(
+        "/api/auth/registration/",
+        {
+            "email": "taken@example.com",
+            "password1": "SuperStrong!23",
+            "password2": "SuperStrong!23",
+            "display_name": "Dup",
+        },
+        format="json",
+    )
+    assert res.status_code == 400, res.content
+    body = res.json()
+    assert "email" in body
+    assert "already" in body["email"][0].lower()
+
+
+@pytest.mark.django_db
 def test_grandfathered_user_can_log_in_without_verification(django_user_model):
     """The 0002 migration runs on the test DB, but it's a one-shot data migration
     and pytest-django creates users post-migration via create_user. Replicate the


### PR DESCRIPTION
## Summary
A user who first logs in via Google OAuth and then tries to register the same email via the password form gets a 500 instead of a clean "email already used" 400. Repro on prod just confirmed: `duplicate key value violates unique constraint "accounts_user_email_key"`.

The root cause is that allauth's social adapter (with `SOCIALACCOUNT_EMAIL_VERIFICATION="none"`) creates the user's `EmailAddress` row with `verified=False`. allauth's pre-flight duplicate check in `RegisterSerializer.validate_email` apparently doesn't catch that case in our setup, so the duplicate slides through to the Postgres `UNIQUE(email)` constraint.

Add an explicit `User.objects.filter(email__iexact=email).exists()` check in `UserRegisterSerializer.validate_email` as belt-and-suspenders. Returns the same shape allauth would (`{"email": ["A user is already registered..."]}`), which the frontend's `describeRegisterError` already maps to "Cet email est déjà utilisé."

## Test plan
- [x] Added `test_register_duplicate_email_returns_400_not_500` — creates a user, attempts to register the same email, asserts 400 with the right error shape.
- [x] Full `test_auth.py` 7/7 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)